### PR TITLE
fix: default filter visibility and statuses

### DIFF
--- a/new-core/src/main/java/io/naryo/application/configuration/source/model/filter/event/EventFilterDescriptor.java
+++ b/new-core/src/main/java/io/naryo/application/configuration/source/model/filter/event/EventFilterDescriptor.java
@@ -34,9 +34,9 @@ public interface EventFilterDescriptor extends FilterDescriptor {
 
     @Override
     default FilterDescriptor merge(FilterDescriptor descriptor) {
-        var filter = FilterDescriptor.super.merge(descriptor);
+        FilterDescriptor.super.merge(descriptor);
 
-        if (filter instanceof EventFilterDescriptor other) {
+        if (descriptor instanceof EventFilterDescriptor other) {
             mergeOptionals(this::setScope, this.getScope(), other.getScope());
             mergeCollections(this::setStatuses, this.getStatuses(), other.getStatuses());
             mergeDescriptors(
@@ -45,6 +45,6 @@ public interface EventFilterDescriptor extends FilterDescriptor {
             mergeDescriptors(this::setVisibility, this.getVisibility(), other.getVisibility());
         }
 
-        return filter;
+        return this;
     }
 }

--- a/new-core/src/main/java/io/naryo/application/configuration/source/model/filter/event/contract/ContractEventFilterDescriptor.java
+++ b/new-core/src/main/java/io/naryo/application/configuration/source/model/filter/event/contract/ContractEventFilterDescriptor.java
@@ -15,12 +15,12 @@ public interface ContractEventFilterDescriptor extends EventFilterDescriptor {
 
     @Override
     default FilterDescriptor merge(FilterDescriptor descriptor) {
-        var filter = EventFilterDescriptor.super.merge(descriptor);
+        EventFilterDescriptor.super.merge(descriptor);
 
-        if (filter instanceof ContractEventFilterDescriptor other) {
+        if (descriptor instanceof ContractEventFilterDescriptor other) {
             mergeOptionals(this::setAddress, this.getAddress(), other.getAddress());
         }
 
-        return filter;
+        return this;
     }
 }

--- a/new-core/src/main/java/io/naryo/application/configuration/source/model/filter/event/sync/BlockFilterSyncDescriptor.java
+++ b/new-core/src/main/java/io/naryo/application/configuration/source/model/filter/event/sync/BlockFilterSyncDescriptor.java
@@ -20,12 +20,12 @@ public interface BlockFilterSyncDescriptor extends FilterSyncDescriptor {
 
     @Override
     default FilterSyncDescriptor merge(FilterSyncDescriptor descriptor) {
-        var sync = FilterSyncDescriptor.super.merge(descriptor);
+        FilterSyncDescriptor.super.merge(descriptor);
 
-        if (sync instanceof BlockFilterSyncDescriptor other) {
+        if (descriptor instanceof BlockFilterSyncDescriptor other) {
             mergeOptionals(this::setInitialBlock, this.getInitialBlock(), other.getInitialBlock());
         }
 
-        return sync;
+        return this;
     }
 }

--- a/new-core/src/main/java/io/naryo/application/configuration/source/model/filter/transaction/TransactionFilterDescriptor.java
+++ b/new-core/src/main/java/io/naryo/application/configuration/source/model/filter/transaction/TransactionFilterDescriptor.java
@@ -29,7 +29,8 @@ public interface TransactionFilterDescriptor extends FilterDescriptor {
         FilterDescriptor.super.merge(descriptor);
 
         if (descriptor instanceof TransactionFilterDescriptor other) {
-            mergeOptionals(this::setIdentifierType, this.getIdentifierType(), other.getIdentifierType());
+            mergeOptionals(
+                    this::setIdentifierType, this.getIdentifierType(), other.getIdentifierType());
             mergeOptionals(this::setValue, this.getValue(), other.getValue());
             mergeCollections(this::setStatuses, this.getStatuses(), other.getStatuses());
         }

--- a/new-core/src/main/java/io/naryo/application/configuration/source/model/filter/transaction/TransactionFilterDescriptor.java
+++ b/new-core/src/main/java/io/naryo/application/configuration/source/model/filter/transaction/TransactionFilterDescriptor.java
@@ -26,15 +26,14 @@ public interface TransactionFilterDescriptor extends FilterDescriptor {
 
     @Override
     default FilterDescriptor merge(FilterDescriptor descriptor) {
-        var filter = FilterDescriptor.super.merge(descriptor);
+        FilterDescriptor.super.merge(descriptor);
 
-        if (filter instanceof TransactionFilterDescriptor other) {
-            mergeOptionals(
-                    this::setIdentifierType, this.getIdentifierType(), other.getIdentifierType());
+        if (descriptor instanceof TransactionFilterDescriptor other) {
+            mergeOptionals(this::setIdentifierType, this.getIdentifierType(), other.getIdentifierType());
             mergeOptionals(this::setValue, this.getValue(), other.getValue());
             mergeCollections(this::setStatuses, this.getStatuses(), other.getStatuses());
         }
 
-        return filter;
+        return this;
     }
 }

--- a/new-core/src/main/java/io/naryo/application/filter/configuration/manager/DefaultFilterConfigurationManager.java
+++ b/new-core/src/main/java/io/naryo/application/filter/configuration/manager/DefaultFilterConfigurationManager.java
@@ -138,16 +138,16 @@ public final class DefaultFilterConfigurationManager
         throw new IllegalArgumentException("Unknown sync strategy: " + descriptor.getStrategy());
     }
 
-    private EventFilterVisibilityConfiguration getVisibilityConfigurationFromDescriptor(
-            FilterVisibilityDescriptor descriptor) {
-        boolean isVisible = valueOrNull(FilterVisibilityDescriptor::getVisible, descriptor);
-
-        if (isVisible) {
-            return EventFilterVisibilityConfiguration.visible();
-        } else {
-            String privacyGroupId =
-                    valueOrNull(FilterVisibilityDescriptor::getPrivacyGroupId, descriptor);
-            return EventFilterVisibilityConfiguration.invisible(privacyGroupId);
-        }
+    private EventFilterVisibilityConfiguration getVisibilityConfigurationFromDescriptor(FilterVisibilityDescriptor descriptor) {
+        return descriptor.getVisible()
+            .map(isVisible -> {
+                if (isVisible) {
+                    return EventFilterVisibilityConfiguration.visible();
+                } else {
+                    String privacyGroupId = valueOrNull(FilterVisibilityDescriptor::getPrivacyGroupId, descriptor);
+                    return EventFilterVisibilityConfiguration.invisible(privacyGroupId);
+                }
+            })
+            .orElse(EventFilterVisibilityConfiguration.visible());
     }
 }

--- a/new-core/src/main/java/io/naryo/application/filter/configuration/manager/DefaultFilterConfigurationManager.java
+++ b/new-core/src/main/java/io/naryo/application/filter/configuration/manager/DefaultFilterConfigurationManager.java
@@ -138,16 +138,22 @@ public final class DefaultFilterConfigurationManager
         throw new IllegalArgumentException("Unknown sync strategy: " + descriptor.getStrategy());
     }
 
-    private EventFilterVisibilityConfiguration getVisibilityConfigurationFromDescriptor(FilterVisibilityDescriptor descriptor) {
-        return descriptor.getVisible()
-            .map(isVisible -> {
-                if (isVisible) {
-                    return EventFilterVisibilityConfiguration.visible();
-                } else {
-                    String privacyGroupId = valueOrNull(FilterVisibilityDescriptor::getPrivacyGroupId, descriptor);
-                    return EventFilterVisibilityConfiguration.invisible(privacyGroupId);
-                }
-            })
-            .orElse(EventFilterVisibilityConfiguration.visible());
+    private EventFilterVisibilityConfiguration getVisibilityConfigurationFromDescriptor(
+            FilterVisibilityDescriptor descriptor) {
+        return descriptor
+                .getVisible()
+                .map(
+                        isVisible -> {
+                            if (isVisible) {
+                                return EventFilterVisibilityConfiguration.visible();
+                            } else {
+                                String privacyGroupId =
+                                        valueOrNull(
+                                                FilterVisibilityDescriptor::getPrivacyGroupId,
+                                                descriptor);
+                                return EventFilterVisibilityConfiguration.invisible(privacyGroupId);
+                            }
+                        })
+                .orElse(EventFilterVisibilityConfiguration.visible());
     }
 }

--- a/new-core/src/main/java/io/naryo/domain/filter/event/EventFilter.java
+++ b/new-core/src/main/java/io/naryo/domain/filter/event/EventFilter.java
@@ -39,7 +39,7 @@ public abstract class EventFilter extends Filter {
         Objects.requireNonNull(visibilityConfiguration, "VisibilityConfiguration cannot be null");
         this.scope = scope;
         this.specification = specification;
-        this.statuses = statuses.isEmpty() ? Set.of(ContractEventStatus.values()) : statuses;
+        this.statuses = statuses == null || statuses.isEmpty() ? Set.of(ContractEventStatus.values()) : statuses;
         this.syncState = syncState;
         this.visibilityConfiguration = visibilityConfiguration;
     }

--- a/new-core/src/main/java/io/naryo/domain/filter/event/EventFilter.java
+++ b/new-core/src/main/java/io/naryo/domain/filter/event/EventFilter.java
@@ -39,7 +39,7 @@ public abstract class EventFilter extends Filter {
         Objects.requireNonNull(visibilityConfiguration, "VisibilityConfiguration cannot be null");
         this.scope = scope;
         this.specification = specification;
-        this.statuses = statuses == null || statuses.isEmpty() ? Set.of(ContractEventStatus.values()) : statuses;
+        this.statuses = statuses.isEmpty() ? Set.of(ContractEventStatus.values()) : statuses;
         this.syncState = syncState;
         this.visibilityConfiguration = visibilityConfiguration;
     }

--- a/new-core/src/main/java/io/naryo/domain/filter/event/EventFilter.java
+++ b/new-core/src/main/java/io/naryo/domain/filter/event/EventFilter.java
@@ -37,12 +37,9 @@ public abstract class EventFilter extends Filter {
         Objects.requireNonNull(statuses, "Statuses cannot be null");
         Objects.requireNonNull(syncState, "SyncState cannot be null");
         Objects.requireNonNull(visibilityConfiguration, "VisibilityConfiguration cannot be null");
-        if (statuses.isEmpty()) {
-            throw new IllegalArgumentException("Statuses cannot be empty");
-        }
         this.scope = scope;
         this.specification = specification;
-        this.statuses = statuses;
+        this.statuses = statuses.isEmpty() ? Set.of(ContractEventStatus.values()) : statuses;
         this.syncState = syncState;
         this.visibilityConfiguration = visibilityConfiguration;
     }

--- a/new-core/src/test/java/io/naryo/domain/filter/event/AbstractEventFilterTest.java
+++ b/new-core/src/test/java/io/naryo/domain/filter/event/AbstractEventFilterTest.java
@@ -72,11 +72,15 @@ abstract class AbstractEventFilterTest {
         Set<ContractEventStatus> statuses = new HashSet<>();
         SyncState syncState = new NoSyncState();
 
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> {
-                    createEventFilter(id, name, nodeId, specification, statuses, syncState);
-                });
+        EventFilter eventFilter =
+            createEventFilter(id, name, nodeId, specification, statuses, syncState);
+
+        assertEquals(id, eventFilter.getId());
+        assertEquals(name, eventFilter.getName());
+        assertEquals(nodeId, eventFilter.getNodeId());
+        assertEquals(specification, eventFilter.getSpecification());
+        assertEquals(Set.of(ContractEventStatus.values()), eventFilter.getStatuses());
+        assertEquals(syncState, eventFilter.getSyncState());
     }
 
     @Test

--- a/new-core/src/test/java/io/naryo/domain/filter/event/AbstractEventFilterTest.java
+++ b/new-core/src/test/java/io/naryo/domain/filter/event/AbstractEventFilterTest.java
@@ -73,7 +73,7 @@ abstract class AbstractEventFilterTest {
         SyncState syncState = new NoSyncState();
 
         EventFilter eventFilter =
-            createEventFilter(id, name, nodeId, specification, statuses, syncState);
+                createEventFilter(id, name, nodeId, specification, statuses, syncState);
 
         assertEquals(id, eventFilter.getId());
         assertEquals(name, eventFilter.getName());

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/filter/event/EventFilterProperties.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/filter/event/EventFilterProperties.java
@@ -45,9 +45,7 @@ public abstract class EventFilterProperties extends FilterProperties
         super(id, name, FilterType.EVENT, nodeId);
         this.scope = scope;
         this.specification = specification;
-        this.statuses = statuses == null || statuses.isEmpty()
-            ? Set.of(ContractEventStatus.values())
-            : statuses;
+        this.statuses = statuses;
         this.sync = sync;
         this.visibility = visibility;
     }

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/filter/event/EventFilterProperties.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/filter/event/EventFilterProperties.java
@@ -45,7 +45,9 @@ public abstract class EventFilterProperties extends FilterProperties
         super(id, name, FilterType.EVENT, nodeId);
         this.scope = scope;
         this.specification = specification;
-        this.statuses = statuses;
+        this.statuses = statuses == null || statuses.isEmpty()
+            ? Set.of(ContractEventStatus.values())
+            : statuses;
         this.sync = sync;
         this.visibility = visibility;
     }


### PR DESCRIPTION
This PR fixes the following cases:
- (**new-core**)
  - Creates a default visible `EventFilterVisibilityConfiguration` if `FilterVisibilityDescriptor.getVisible()` is `null` or visible
  - Fixes `merge` methods for `Filter` related descriptors
  - Creates default EventFilter statuses as a set of all possible `ContractEventStatus` if received Set is empty