### PR TITLE
chore: Add optional to node descriptors & node env

### DIFF
--- a/new-core/src/main/java/io/naryo/application/configuration/source/model/node/NodeDescriptor.java
+++ b/new-core/src/main/java/io/naryo/application/configuration/source/model/node/NodeDescriptor.java
@@ -1,5 +1,6 @@
 package io.naryo.application.configuration.source.model.node;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import io.naryo.application.configuration.source.model.MergeableDescriptor;
@@ -8,21 +9,25 @@ import io.naryo.application.configuration.source.model.node.interaction.Interact
 import io.naryo.application.configuration.source.model.node.subscription.SubscriptionDescriptor;
 import io.naryo.domain.node.NodeType;
 
+import static io.naryo.application.common.util.MergeUtil.mergeOptionals;
+
 public interface NodeDescriptor extends MergeableDescriptor<NodeDescriptor> {
 
     UUID getId();
 
-    String getName();
+    Optional<String> getName();
 
-    NodeType getType();
+    Optional<NodeType> getType();
 
-    SubscriptionDescriptor getSubscription();
+    Optional<SubscriptionDescriptor> getSubscription();
 
-    InteractionDescriptor getInteraction();
+    Optional<InteractionDescriptor> getInteraction();
 
-    NodeConnectionDescriptor getConnection();
+    Optional<NodeConnectionDescriptor> getConnection();
 
     void setName(String name);
+
+    void setType(NodeType type);
 
     void setSubscription(SubscriptionDescriptor subscription);
 
@@ -36,42 +41,40 @@ public interface NodeDescriptor extends MergeableDescriptor<NodeDescriptor> {
             return this;
         }
 
-        if (!this.getName().equals(descriptor.getName())) {
-            this.setName(descriptor.getName());
-        }
+        mergeOptionals(this::setName, this.getName(), descriptor.getName());
+        mergeOptionals(this::setType, this.getType(), descriptor.getType());
 
-        if (!this.getType().equals(descriptor.getType())) {
-            return descriptor;
-        }
+        descriptor.getSubscription().ifPresent(newSubscription -> {
+            this.getSubscription().ifPresentOrElse(
+                currentSubscription -> {
+                    if (!newSubscription.getClass().equals(currentSubscription.getClass())) {
+                        this.setSubscription(newSubscription);
+                    } else {
+                        this.setSubscription(currentSubscription.merge(newSubscription));
+                    }
+                },
+                () -> this.setSubscription(newSubscription)
+            );
+        });
 
-        if (descriptor.getSubscription() != null) {
-            if (this.getSubscription() == null) {
-                this.setSubscription(descriptor.getSubscription());
-            } else if (!descriptor
-                    .getSubscription()
-                    .getClass()
-                    .equals(this.getSubscription().getClass())) {
-                this.setSubscription(descriptor.getSubscription());
-            } else {
-                this.setSubscription(this.getSubscription().merge(descriptor.getSubscription()));
-            }
-        }
 
-        if (descriptor.getInteraction() != null) {
-            if (this.getInteraction() == null) {
-                this.setInteraction(descriptor.getInteraction());
-            } else {
-                this.getInteraction().merge(descriptor.getInteraction());
-            }
-        }
+        descriptor.getInteraction().ifPresent(newInteraction -> {
+            this.getInteraction().ifPresentOrElse(
+                currentInteraction -> {
+                    currentInteraction.merge(newInteraction);
+                },
+                () -> this.setInteraction(newInteraction)
+            );
+        });
 
-        if (descriptor.getConnection() != null) {
-            if (this.getConnection() == null) {
-                this.setConnection(descriptor.getConnection());
-            } else {
-                this.getConnection().merge(descriptor.getConnection());
-            }
-        }
+        descriptor.getConnection().ifPresent(newConnection -> {
+            this.getConnection().ifPresentOrElse(
+                currentConnection -> {
+                    currentConnection.merge(newConnection);
+                },
+                () -> this.setConnection(newConnection)
+            );
+        });
 
         return this;
     }

--- a/new-core/src/main/java/io/naryo/application/configuration/source/model/node/PrivateEthereumNodeDescriptor.java
+++ b/new-core/src/main/java/io/naryo/application/configuration/source/model/node/PrivateEthereumNodeDescriptor.java
@@ -1,10 +1,14 @@
 package io.naryo.application.configuration.source.model.node;
 
+import java.util.Optional;
+
+import static io.naryo.application.common.util.MergeUtil.mergeOptionals;
+
 public interface PrivateEthereumNodeDescriptor extends EthereumNodeDescriptor {
 
-    String getGroupId();
+    Optional<String> getGroupId();
 
-    String getPrecompiledAddress();
+    Optional<String> getPrecompiledAddress();
 
     void setGroupId(String groupId);
 
@@ -15,12 +19,8 @@ public interface PrivateEthereumNodeDescriptor extends EthereumNodeDescriptor {
         var result = EthereumNodeDescriptor.super.merge(descriptor);
 
         if (descriptor instanceof PrivateEthereumNodeDescriptor other) {
-            if (!this.getGroupId().equals(other.getGroupId())) {
-                this.setGroupId(other.getGroupId());
-            }
-            if (!this.getPrecompiledAddress().equals(other.getPrecompiledAddress())) {
-                this.setPrecompiledAddress(other.getPrecompiledAddress());
-            }
+            mergeOptionals(this::setGroupId, this.getGroupId(), other.getGroupId());
+            mergeOptionals(this::setPrecompiledAddress, this.getPrecompiledAddress(), other.getPrecompiledAddress());
         }
 
         return result;

--- a/new-core/src/main/java/io/naryo/application/configuration/source/model/node/connection/HttpNodeConnectionDescriptor.java
+++ b/new-core/src/main/java/io/naryo/application/configuration/source/model/node/connection/HttpNodeConnectionDescriptor.java
@@ -1,8 +1,11 @@
 package io.naryo.application.configuration.source.model.node.connection;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import io.naryo.domain.node.connection.NodeConnectionType;
+
+import static io.naryo.application.common.util.MergeUtil.mergeOptionals;
 
 public interface HttpNodeConnectionDescriptor extends NodeConnectionDescriptor {
 
@@ -11,15 +14,15 @@ public interface HttpNodeConnectionDescriptor extends NodeConnectionDescriptor {
         return NodeConnectionType.HTTP;
     }
 
-    int getMaxIdleConnections();
+    Optional<Integer> getMaxIdleConnections();
 
-    Duration getKeepAliveDuration();
+    Optional<Duration> getKeepAliveDuration();
 
-    Duration getConnectionTimeout();
+    Optional<Duration> getConnectionTimeout();
 
-    Duration getReadTimeout();
+    Optional<Duration> getReadTimeout();
 
-    void setMaxIdleConnections(int maxIdleConnections);
+    void setMaxIdleConnections(Integer maxIdleConnections);
 
     void setKeepAliveDuration(Duration keepAliveDuration);
 
@@ -32,21 +35,10 @@ public interface HttpNodeConnectionDescriptor extends NodeConnectionDescriptor {
         var connection = NodeConnectionDescriptor.super.merge(other);
 
         if (other instanceof HttpNodeConnectionDescriptor otherDescriptor) {
-            if (this.getMaxIdleConnections() != otherDescriptor.getMaxIdleConnections()) {
-                this.setMaxIdleConnections(otherDescriptor.getMaxIdleConnections());
-            }
-
-            if (this.getKeepAliveDuration() != otherDescriptor.getKeepAliveDuration()) {
-                this.setKeepAliveDuration(otherDescriptor.getKeepAliveDuration());
-            }
-
-            if (this.getConnectionTimeout() != otherDescriptor.getConnectionTimeout()) {
-                this.setConnectionTimeout(otherDescriptor.getConnectionTimeout());
-            }
-
-            if (this.getReadTimeout() != otherDescriptor.getReadTimeout()) {
-                this.setReadTimeout(otherDescriptor.getReadTimeout());
-            }
+            mergeOptionals(this::setMaxIdleConnections, this.getMaxIdleConnections(), otherDescriptor.getMaxIdleConnections());
+            mergeOptionals(this::setKeepAliveDuration, this.getKeepAliveDuration(), otherDescriptor.getKeepAliveDuration());
+            mergeOptionals(this::setConnectionTimeout, this.getConnectionTimeout(), otherDescriptor.getConnectionTimeout());
+            mergeOptionals(this::setReadTimeout, this.getReadTimeout(), otherDescriptor.getReadTimeout());
         }
 
         return connection;

--- a/new-core/src/main/java/io/naryo/application/configuration/source/model/node/connection/NodeConnectionDescriptor.java
+++ b/new-core/src/main/java/io/naryo/application/configuration/source/model/node/connection/NodeConnectionDescriptor.java
@@ -5,13 +5,17 @@ import io.naryo.application.configuration.source.model.node.connection.endpoint.
 import io.naryo.application.configuration.source.model.node.connection.retry.NodeConnectionRetryDescriptor;
 import io.naryo.domain.node.connection.NodeConnectionType;
 
+import java.util.Optional;
+
+import static io.naryo.application.common.util.MergeUtil.mergeOptionals;
+
 public interface NodeConnectionDescriptor extends MergeableDescriptor<NodeConnectionDescriptor> {
 
     NodeConnectionType getType();
 
-    ConnectionEndpointDescriptor getEndpoint();
+    Optional<ConnectionEndpointDescriptor> getEndpoint();
 
-    NodeConnectionRetryDescriptor getRetry();
+    Optional<NodeConnectionRetryDescriptor> getRetry();
 
     void setEndpoint(ConnectionEndpointDescriptor endpoint);
 
@@ -27,13 +31,8 @@ public interface NodeConnectionDescriptor extends MergeableDescriptor<NodeConnec
             return other;
         }
 
-        if (!this.getEndpoint().equals(other.getEndpoint())) {
-            this.setEndpoint(this.getEndpoint().merge(other.getEndpoint()));
-        }
-
-        if (this.getRetry() != null && other.getRetry() != null) {
-            this.setRetry(this.getRetry().merge(other.getRetry()));
-        }
+        mergeOptionals(this::setEndpoint, this.getEndpoint(), other.getEndpoint());
+        mergeOptionals(this::setRetry, this.getRetry(), other.getRetry());
 
         return this;
     }

--- a/new-core/src/main/java/io/naryo/application/configuration/source/model/node/connection/endpoint/ConnectionEndpointDescriptor.java
+++ b/new-core/src/main/java/io/naryo/application/configuration/source/model/node/connection/endpoint/ConnectionEndpointDescriptor.java
@@ -2,10 +2,14 @@ package io.naryo.application.configuration.source.model.node.connection.endpoint
 
 import io.naryo.application.configuration.source.model.MergeableDescriptor;
 
+import java.util.Optional;
+
+import static io.naryo.application.common.util.MergeUtil.mergeOptionals;
+
 public interface ConnectionEndpointDescriptor
         extends MergeableDescriptor<ConnectionEndpointDescriptor> {
 
-    String getUrl();
+    Optional<String> getUrl();
 
     void setUrl(String url);
 
@@ -15,9 +19,7 @@ public interface ConnectionEndpointDescriptor
             return this;
         }
 
-        if (!this.getUrl().equals(other.getUrl())) {
-            this.setUrl(other.getUrl());
-        }
+        mergeOptionals(this::setUrl, this.getUrl(), other.getUrl());
 
         return this;
     }

--- a/new-core/src/main/java/io/naryo/application/configuration/source/model/node/connection/retry/NodeConnectionRetryDescriptor.java
+++ b/new-core/src/main/java/io/naryo/application/configuration/source/model/node/connection/retry/NodeConnectionRetryDescriptor.java
@@ -1,15 +1,18 @@
 package io.naryo.application.configuration.source.model.node.connection.retry;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import io.naryo.application.configuration.source.model.MergeableDescriptor;
+
+import static io.naryo.application.common.util.MergeUtil.mergeOptionals;
 
 public interface NodeConnectionRetryDescriptor
         extends MergeableDescriptor<NodeConnectionRetryDescriptor> {
 
-    Integer getTimes();
+    Optional<Integer> getTimes();
 
-    Duration getBackoff();
+    Optional<Duration> getBackoff();
 
     void setTimes(Integer times);
 
@@ -21,13 +24,8 @@ public interface NodeConnectionRetryDescriptor
             return this;
         }
 
-        if (!this.getTimes().equals(other.getTimes())) {
-            this.setTimes(other.getTimes());
-        }
-
-        if (!this.getBackoff().equals(other.getBackoff())) {
-            this.setBackoff(other.getBackoff());
-        }
+        mergeOptionals(this::setTimes, this.getTimes(), other.getTimes());
+        mergeOptionals(this::setBackoff, this.getBackoff(), other.getBackoff());
 
         return this;
     }

--- a/new-core/src/main/java/io/naryo/application/configuration/source/model/node/interaction/HederaMirrorNodeBlockInteractionDescriptor.java
+++ b/new-core/src/main/java/io/naryo/application/configuration/source/model/node/interaction/HederaMirrorNodeBlockInteractionDescriptor.java
@@ -1,10 +1,14 @@
 package io.naryo.application.configuration.source.model.node.interaction;
 
+import java.util.Optional;
+
+import static io.naryo.application.common.util.MergeUtil.mergeOptionals;
+
 public interface HederaMirrorNodeBlockInteractionDescriptor extends BlockInteractionDescriptor {
 
-    Integer getLimitPerRequest();
+    Optional<Integer> getLimitPerRequest();
 
-    Integer getRetriesPerRequest();
+    Optional<Integer> getRetriesPerRequest();
 
     void setLimitPerRequest(Integer limit);
 
@@ -12,18 +16,13 @@ public interface HederaMirrorNodeBlockInteractionDescriptor extends BlockInterac
 
     @Override
     default InteractionDescriptor merge(InteractionDescriptor other) {
-        var interaction = BlockInteractionDescriptor.super.merge(other);
+        BlockInteractionDescriptor.super.merge(other);
 
-        if (interaction instanceof HederaMirrorNodeBlockInteractionDescriptor otherDescriptor) {
-            if (!this.getLimitPerRequest().equals(otherDescriptor.getLimitPerRequest())) {
-                this.setLimitPerRequest(otherDescriptor.getLimitPerRequest());
-            }
-
-            if (!this.getRetriesPerRequest().equals(otherDescriptor.getRetriesPerRequest())) {
-                this.setRetriesPerRequest(otherDescriptor.getRetriesPerRequest());
-            }
+        if (other instanceof HederaMirrorNodeBlockInteractionDescriptor otherDescriptor) {
+            mergeOptionals(this::setLimitPerRequest, this.getLimitPerRequest(), otherDescriptor.getLimitPerRequest());
+            mergeOptionals(this::setRetriesPerRequest, this.getRetriesPerRequest(), otherDescriptor.getRetriesPerRequest());
         }
 
-        return interaction;
+        return this;
     }
 }

--- a/new-core/src/main/java/io/naryo/application/configuration/source/model/node/subscription/BlockSubscriptionDescriptor.java
+++ b/new-core/src/main/java/io/naryo/application/configuration/source/model/node/subscription/BlockSubscriptionDescriptor.java
@@ -1,6 +1,7 @@
 package io.naryo.application.configuration.source.model.node.subscription;
 
 import java.math.BigInteger;
+import java.util.Optional;
 
 import io.naryo.domain.node.subscription.SubscriptionStrategy;
 import io.naryo.domain.node.subscription.block.method.BlockSubscriptionMethod;
@@ -9,17 +10,17 @@ public interface BlockSubscriptionDescriptor extends SubscriptionDescriptor {
 
     BlockSubscriptionMethod method();
 
-    BigInteger getInitialBlock();
+    Optional<BigInteger> getInitialBlock();
 
-    BigInteger getConfirmationBlocks();
+    Optional<BigInteger> getConfirmationBlocks();
 
-    BigInteger getMissingTxRetryBlocks();
+    Optional<BigInteger> getMissingTxRetryBlocks();
 
-    BigInteger getEventInvalidationBlockThreshold();
+    Optional<BigInteger> getEventInvalidationBlockThreshold();
 
-    BigInteger getReplayBlockOffset();
+    Optional<BigInteger> getReplayBlockOffset();
 
-    BigInteger getSyncBlockLimit();
+    Optional<BigInteger> getSyncBlockLimit();
 
     void setInitialBlock(BigInteger initialBlock);
 
@@ -28,7 +29,7 @@ public interface BlockSubscriptionDescriptor extends SubscriptionDescriptor {
     void setMissingTxRetryBlocks(BigInteger missingTxRetryBlocks);
 
     @Override
-    default SubscriptionStrategy strategy() {
+    default SubscriptionStrategy getStrategy() {
         return SubscriptionStrategy.BLOCK_BASED;
     }
 

--- a/new-core/src/main/java/io/naryo/application/configuration/source/model/node/subscription/PollBlockSubscriptionDescriptor.java
+++ b/new-core/src/main/java/io/naryo/application/configuration/source/model/node/subscription/PollBlockSubscriptionDescriptor.java
@@ -1,12 +1,13 @@
 package io.naryo.application.configuration.source.model.node.subscription;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import io.naryo.domain.node.subscription.block.method.BlockSubscriptionMethod;
 
 public interface PollBlockSubscriptionDescriptor extends BlockSubscriptionDescriptor {
 
-    Duration getInterval();
+    Optional<Duration> getInterval();
 
     void setInterval(Duration interval);
 

--- a/new-core/src/main/java/io/naryo/application/configuration/source/model/node/subscription/SubscriptionDescriptor.java
+++ b/new-core/src/main/java/io/naryo/application/configuration/source/model/node/subscription/SubscriptionDescriptor.java
@@ -5,14 +5,14 @@ import io.naryo.domain.node.subscription.SubscriptionStrategy;
 
 public interface SubscriptionDescriptor extends MergeableDescriptor<SubscriptionDescriptor> {
 
-    SubscriptionStrategy strategy();
+    SubscriptionStrategy getStrategy();
 
     default SubscriptionDescriptor merge(SubscriptionDescriptor descriptor) {
         if (descriptor == null) {
             return this;
         }
 
-        if (!this.strategy().equals(descriptor.strategy())) {
+        if (!this.getStrategy().equals(descriptor.getStrategy())) {
             return descriptor;
         }
 

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/common/ConnectionEndpointProperties.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/common/ConnectionEndpointProperties.java
@@ -1,17 +1,23 @@
 package io.naryo.infrastructure.configuration.source.env.model.common;
 
 import io.naryo.application.configuration.source.model.node.connection.endpoint.ConnectionEndpointDescriptor;
-import jakarta.validation.constraints.NotBlank;
-import lombok.Getter;
+import jakarta.annotation.Nullable;
 import lombok.Setter;
+
+import java.util.Optional;
 
 public final class ConnectionEndpointProperties implements ConnectionEndpointDescriptor {
 
-    private @Getter @Setter @NotBlank String url;
+    private @Setter @Nullable String url;
 
     public ConnectionEndpointProperties(String url) {
         this.url = url;
     }
 
     public ConnectionEndpointProperties() {}
+
+    @Override
+    public Optional<String> getUrl() {
+        return Optional.ofNullable(url);
+    }
 }

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/NodeProperties.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/NodeProperties.java
@@ -1,26 +1,38 @@
 package io.naryo.infrastructure.configuration.source.env.model.node;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import io.naryo.application.configuration.source.model.node.NodeDescriptor;
+import io.naryo.application.configuration.source.model.node.connection.HttpNodeConnectionDescriptor;
 import io.naryo.application.configuration.source.model.node.connection.NodeConnectionDescriptor;
+import io.naryo.application.configuration.source.model.node.connection.WsNodeConnectionDescriptor;
+import io.naryo.application.configuration.source.model.node.interaction.EthereumRpcBlockInteractionDescriptor;
+import io.naryo.application.configuration.source.model.node.interaction.HederaMirrorNodeBlockInteractionDescriptor;
 import io.naryo.application.configuration.source.model.node.interaction.InteractionDescriptor;
 import io.naryo.application.configuration.source.model.node.subscription.SubscriptionDescriptor;
 import io.naryo.domain.node.NodeType;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
+import io.naryo.infrastructure.configuration.source.env.model.node.connection.http.HttpConnectionProperties;
+import io.naryo.infrastructure.configuration.source.env.model.node.connection.ws.WsConnectionProperties;
+import io.naryo.infrastructure.configuration.source.env.model.node.interaction.block.EthereumRpcBlockInteractionProperties;
+import io.naryo.infrastructure.configuration.source.env.model.node.interaction.block.HederaMirrorNodeBlockInteractionProperties;
+import io.naryo.infrastructure.configuration.source.env.model.node.subscription.block.PollBlockSubscriptionProperties;
+import io.naryo.infrastructure.configuration.source.env.model.node.subscription.block.PubsubBlockSubscriptionProperties;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
+import static io.naryo.application.common.util.OptionalUtil.valueOrNull;
+
 public abstract class NodeProperties implements NodeDescriptor {
 
     private final @Getter @NotNull UUID id;
-    private final @Getter @NotNull NodeType type;
-    private @Getter @Setter @NotBlank String name;
-    private @Getter @Setter @Valid @NotNull SubscriptionDescriptor subscription;
-    private @Getter @Setter @Valid @NotNull InteractionDescriptor interaction;
-    private @Getter @Setter @Valid @NotNull NodeConnectionDescriptor connection;
+    private @Setter @Nullable NodeType type;
+    private @Setter @Nullable String name;
+    private @Nullable SubscriptionDescriptor subscription;
+    private @Nullable InteractionDescriptor interaction;
+    private @Nullable NodeConnectionDescriptor connection;
 
     protected NodeProperties(
             UUID id,
@@ -35,5 +47,90 @@ public abstract class NodeProperties implements NodeDescriptor {
         this.subscription = subscription;
         this.interaction = interaction;
         this.connection = connection;
+    }
+
+    @Override
+    public Optional<String> getName() {
+        return Optional.ofNullable(name);
+    }
+
+    @Override
+    public Optional<NodeType> getType() {
+        return Optional.ofNullable(type);
+    }
+
+    @Override
+    public Optional<SubscriptionDescriptor> getSubscription() {
+        return Optional.ofNullable(subscription);
+    }
+
+    @Override
+    public void setSubscription(SubscriptionDescriptor subscription) {
+        switch(subscription) {
+            case PubsubBlockSubscriptionProperties pubsub ->
+                this.subscription = new PubsubBlockSubscriptionProperties(
+                    valueOrNull(pubsub.getInitialBlock()),
+                    valueOrNull(pubsub.getConfirmationBlocks()),
+                    valueOrNull(pubsub.getMissingTxRetryBlocks()),
+                    valueOrNull(pubsub.getEventInvalidationBlockThreshold()),
+                    valueOrNull(pubsub.getReplayBlockOffset()),
+                    valueOrNull(pubsub.getSyncBlockLimit())
+                );
+            case PollBlockSubscriptionProperties poll ->
+                this.subscription = new PollBlockSubscriptionProperties(
+                    valueOrNull(poll.getInitialBlock()),
+                    valueOrNull(poll.getConfirmationBlocks()),
+                    valueOrNull(poll.getMissingTxRetryBlocks()),
+                    valueOrNull(poll.getEventInvalidationBlockThreshold()),
+                    valueOrNull(poll.getReplayBlockOffset()),
+                    valueOrNull(poll.getSyncBlockLimit()),
+                    valueOrNull(poll.getInterval())
+                );
+            default -> throw new IllegalArgumentException("Unsupported subscription type: " + subscription.getClass().getSimpleName());
+        }
+    }
+
+    @Override
+    public Optional<InteractionDescriptor> getInteraction() {
+        return Optional.ofNullable(interaction);
+    }
+
+    @Override
+    public void setInteraction(InteractionDescriptor interaction) {
+        switch(interaction) {
+            case EthereumRpcBlockInteractionDescriptor ignored ->
+                this.interaction = new EthereumRpcBlockInteractionProperties();
+            case HederaMirrorNodeBlockInteractionDescriptor hedera ->
+                this.interaction = new HederaMirrorNodeBlockInteractionProperties(
+                    valueOrNull(hedera.getLimitPerRequest()),
+                    valueOrNull(hedera.getRetriesPerRequest()));
+            default -> throw new IllegalArgumentException("Unsupported interaction type: " + interaction.getClass().getSimpleName());
+        }
+    }
+
+    @Override
+    public Optional<NodeConnectionDescriptor> getConnection() {
+        return Optional.ofNullable(connection);
+    }
+
+    @Override
+    public void setConnection(NodeConnectionDescriptor connection) {
+        switch (connection) {
+            case HttpNodeConnectionDescriptor http ->
+                this.connection = new HttpConnectionProperties(
+                    valueOrNull(http.getRetry()),
+                    valueOrNull(http.getEndpoint()),
+                    valueOrNull(http.getMaxIdleConnections()),
+                    valueOrNull(http.getKeepAliveDuration()),
+                    valueOrNull(http.getConnectionTimeout()),
+                    valueOrNull(http.getReadTimeout())
+                );
+            case WsNodeConnectionDescriptor ws ->
+                this.connection = new WsConnectionProperties(
+                    valueOrNull(ws.getRetry()),
+                    valueOrNull(ws.getEndpoint())
+                );
+            default -> throw new IllegalArgumentException("Unsupported connection type: " + connection.getClass().getSimpleName());
+        }
     }
 }

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/connection/ConnectionProperties.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/connection/ConnectionProperties.java
@@ -1,24 +1,53 @@
 package io.naryo.infrastructure.configuration.source.env.model.node.connection;
 
+import io.naryo.application.configuration.source.model.node.connection.NodeConnectionDescriptor;
+import io.naryo.application.configuration.source.model.node.connection.endpoint.ConnectionEndpointDescriptor;
+import io.naryo.application.configuration.source.model.node.connection.retry.NodeConnectionRetryDescriptor;
 import io.naryo.domain.node.connection.NodeConnectionType;
 import io.naryo.infrastructure.configuration.source.env.model.common.ConnectionEndpointProperties;
+import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import lombok.Setter;
 
-public abstract class ConnectionProperties {
+import java.util.Optional;
+
+import static io.naryo.application.common.util.OptionalUtil.valueOrNull;
+
+public abstract class ConnectionProperties implements NodeConnectionDescriptor {
 
     private final @Getter @NotNull NodeConnectionType type;
-    private @Getter @Setter @Valid @NotNull NodeConnectionRetryProperties retry;
-    private @Getter @Setter @Valid @NotNull ConnectionEndpointProperties endpoint;
+    private @Valid @Nullable NodeConnectionRetryDescriptor retry;
+    private @Valid @Nullable ConnectionEndpointDescriptor endpoint;
 
     public ConnectionProperties(
             NodeConnectionType type,
-            NodeConnectionRetryProperties retry,
-            ConnectionEndpointProperties endpoint) {
+            NodeConnectionRetryDescriptor retry,
+            ConnectionEndpointDescriptor endpoint) {
         this.type = type;
         this.retry = retry;
         this.endpoint = endpoint;
+    }
+
+    @Override
+    public Optional<NodeConnectionRetryDescriptor> getRetry() {
+        return Optional.ofNullable(retry);
+    }
+
+    @Override
+    public void setRetry(NodeConnectionRetryDescriptor retry) {
+        this.retry = new NodeConnectionRetryProperties(
+            valueOrNull(retry.getTimes()), valueOrNull(retry.getBackoff())
+        );
+    }
+
+    @Override
+    public Optional<ConnectionEndpointDescriptor> getEndpoint() {
+        return Optional.ofNullable(endpoint);
+    }
+
+    @Override
+    public void setEndpoint(ConnectionEndpointDescriptor endpoint) {
+        this.endpoint = new ConnectionEndpointProperties(valueOrNull(endpoint.getUrl()));
     }
 }

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/connection/NodeConnectionRetryProperties.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/connection/NodeConnectionRetryProperties.java
@@ -1,8 +1,10 @@
 package io.naryo.infrastructure.configuration.source.env.model.node.connection;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import io.naryo.application.configuration.source.model.node.connection.retry.NodeConnectionRetryDescriptor;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,15 +14,25 @@ public final class NodeConnectionRetryProperties implements NodeConnectionRetryD
     private static final Integer DEFAULT_RETRY_TIMES = 3;
     private static final Duration DEFAULT_BACKOFF = Duration.ofSeconds(30);
 
-    private @Getter @Setter Integer times;
-    private @Getter @Setter @NotNull Duration backoff;
+    private @Setter @Nullable Integer times;
+    private @Setter @Nullable Duration backoff;
 
-    public NodeConnectionRetryProperties(int times, Duration backoff) {
+    public NodeConnectionRetryProperties(Integer times, Duration backoff) {
         this.times = times;
         this.backoff = backoff;
     }
 
     public NodeConnectionRetryProperties() {
         this(DEFAULT_RETRY_TIMES, DEFAULT_BACKOFF);
+    }
+
+    @Override
+    public Optional<Integer> getTimes() {
+        return Optional.ofNullable(times);
+    }
+
+    @Override
+    public Optional<Duration> getBackoff() {
+        return Optional.ofNullable(backoff);
     }
 }

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/connection/http/HttpConnectionProperties.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/connection/http/HttpConnectionProperties.java
@@ -1,6 +1,7 @@
 package io.naryo.infrastructure.configuration.source.env.model.node.connection.http;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import io.naryo.application.configuration.source.model.node.connection.HttpNodeConnectionDescriptor;
 import io.naryo.application.configuration.source.model.node.connection.endpoint.ConnectionEndpointDescriptor;
@@ -9,6 +10,7 @@ import io.naryo.domain.node.connection.NodeConnectionType;
 import io.naryo.infrastructure.configuration.source.env.model.common.ConnectionEndpointProperties;
 import io.naryo.infrastructure.configuration.source.env.model.node.connection.ConnectionProperties;
 import io.naryo.infrastructure.configuration.source.env.model.node.connection.NodeConnectionRetryProperties;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
@@ -21,14 +23,14 @@ public final class HttpConnectionProperties extends ConnectionProperties
     private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(10);
     private static final Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(30);
 
-    private @Getter @Setter int maxIdleConnections;
-    private @Getter @Setter @NotNull Duration keepAliveDuration;
-    private @Getter @Setter @NotNull Duration connectionTimeout;
-    private @Getter @Setter @NotNull Duration readTimeout;
+    private @Setter @Nullable Integer maxIdleConnections;
+    private @Setter @Nullable Duration keepAliveDuration;
+    private @Setter @Nullable Duration connectionTimeout;
+    private @Setter @Nullable Duration readTimeout;
 
     public HttpConnectionProperties(
-            NodeConnectionRetryProperties retry,
-            ConnectionEndpointProperties endpoint,
+            NodeConnectionRetryDescriptor retry,
+            ConnectionEndpointDescriptor endpoint,
             Integer maxIdleConnections,
             Duration keepAliveDuration,
             Duration connectionTimeout,
@@ -55,12 +57,22 @@ public final class HttpConnectionProperties extends ConnectionProperties
     }
 
     @Override
-    public void setEndpoint(ConnectionEndpointDescriptor endpoint) {
-        this.setEndpoint((ConnectionEndpointProperties) endpoint);
+    public Optional<Integer> getMaxIdleConnections() {
+        return Optional.ofNullable(maxIdleConnections);
     }
 
     @Override
-    public void setRetry(NodeConnectionRetryDescriptor retry) {
-        this.setRetry((NodeConnectionRetryProperties) retry);
+    public Optional<Duration> getKeepAliveDuration() {
+        return Optional.ofNullable(keepAliveDuration);
+    }
+
+    @Override
+    public Optional<Duration> getConnectionTimeout() {
+        return Optional.ofNullable(connectionTimeout);
+    }
+
+    @Override
+    public Optional<Duration> getReadTimeout() {
+        return Optional.ofNullable(readTimeout);
     }
 }

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/connection/ws/WsConnectionProperties.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/connection/ws/WsConnectionProperties.java
@@ -4,25 +4,13 @@ import io.naryo.application.configuration.source.model.node.connection.WsNodeCon
 import io.naryo.application.configuration.source.model.node.connection.endpoint.ConnectionEndpointDescriptor;
 import io.naryo.application.configuration.source.model.node.connection.retry.NodeConnectionRetryDescriptor;
 import io.naryo.domain.node.connection.NodeConnectionType;
-import io.naryo.infrastructure.configuration.source.env.model.common.ConnectionEndpointProperties;
 import io.naryo.infrastructure.configuration.source.env.model.node.connection.ConnectionProperties;
-import io.naryo.infrastructure.configuration.source.env.model.node.connection.NodeConnectionRetryProperties;
 
 public final class WsConnectionProperties extends ConnectionProperties
         implements WsNodeConnectionDescriptor {
 
     public WsConnectionProperties(
-            NodeConnectionRetryProperties retry, ConnectionEndpointProperties endpoint) {
+            NodeConnectionRetryDescriptor retry, ConnectionEndpointDescriptor endpoint) {
         super(NodeConnectionType.WS, retry, endpoint);
-    }
-
-    @Override
-    public void setEndpoint(ConnectionEndpointDescriptor endpoint) {
-        this.setEndpoint((ConnectionEndpointProperties) endpoint);
-    }
-
-    @Override
-    public void setRetry(NodeConnectionRetryDescriptor retry) {
-        this.setRetry((NodeConnectionRetryProperties) retry);
     }
 }

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/ethereum/PrivateEthereumNodeProperties.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/ethereum/PrivateEthereumNodeProperties.java
@@ -1,5 +1,6 @@
 package io.naryo.infrastructure.configuration.source.env.model.node.ethereum;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import io.naryo.application.configuration.source.model.node.PrivateEthereumNodeDescriptor;
@@ -7,15 +8,14 @@ import io.naryo.application.configuration.source.model.node.connection.NodeConne
 import io.naryo.application.configuration.source.model.node.interaction.InteractionDescriptor;
 import io.naryo.application.configuration.source.model.node.subscription.SubscriptionDescriptor;
 import io.naryo.domain.node.ethereum.EthereumNodeVisibility;
-import jakarta.validation.constraints.NotBlank;
-import lombok.Getter;
+import jakarta.annotation.Nullable;
 import lombok.Setter;
 
 public final class PrivateEthereumNodeProperties extends EthereumNodeProperties
         implements PrivateEthereumNodeDescriptor {
 
-    private @Getter @Setter @NotBlank String groupId;
-    private @Getter @Setter @NotBlank String precompiledAddress;
+    private @Setter @Nullable String groupId;
+    private @Setter @Nullable String precompiledAddress;
 
     public PrivateEthereumNodeProperties(
             UUID id,
@@ -28,5 +28,15 @@ public final class PrivateEthereumNodeProperties extends EthereumNodeProperties
         super(id, name, subscription, interaction, connection, EthereumNodeVisibility.PRIVATE);
         this.groupId = groupId;
         this.precompiledAddress = precompiledAddress;
+    }
+
+    @Override
+    public Optional<String> getGroupId() {
+        return Optional.ofNullable(groupId);
+    }
+
+    @Override
+    public Optional<String> getPrecompiledAddress() {
+        return Optional.ofNullable(precompiledAddress);
     }
 }

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/interaction/InteractionProperties.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/interaction/InteractionProperties.java
@@ -1,10 +1,11 @@
 package io.naryo.infrastructure.configuration.source.env.model.node.interaction;
 
+import io.naryo.application.configuration.source.model.node.interaction.InteractionDescriptor;
 import io.naryo.domain.node.interaction.InteractionStrategy;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
-public abstract class InteractionProperties {
+public abstract class InteractionProperties implements InteractionDescriptor {
 
     private final @Getter @NotNull InteractionStrategy strategy;
 

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/interaction/block/BlockInteractionProperties.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/interaction/block/BlockInteractionProperties.java
@@ -1,12 +1,13 @@
 package io.naryo.infrastructure.configuration.source.env.model.node.interaction.block;
 
+import io.naryo.application.configuration.source.model.node.interaction.BlockInteractionDescriptor;
 import io.naryo.domain.node.interaction.InteractionStrategy;
 import io.naryo.domain.node.interaction.block.InteractionMode;
 import io.naryo.infrastructure.configuration.source.env.model.node.interaction.InteractionProperties;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
-public abstract class BlockInteractionProperties extends InteractionProperties {
+public abstract class BlockInteractionProperties extends InteractionProperties implements BlockInteractionDescriptor {
 
     private final @Getter @NotNull InteractionMode mode;
 

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/interaction/block/HederaMirrorNodeBlockInteractionProperties.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/interaction/block/HederaMirrorNodeBlockInteractionProperties.java
@@ -2,9 +2,10 @@ package io.naryo.infrastructure.configuration.source.env.model.node.interaction.
 
 import io.naryo.application.configuration.source.model.node.interaction.HederaMirrorNodeBlockInteractionDescriptor;
 import io.naryo.domain.node.interaction.block.InteractionMode;
-import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
+import jakarta.annotation.Nullable;
 import lombok.Setter;
+
+import java.util.Optional;
 
 public class HederaMirrorNodeBlockInteractionProperties extends BlockInteractionProperties
         implements HederaMirrorNodeBlockInteractionDescriptor {
@@ -12,8 +13,8 @@ public class HederaMirrorNodeBlockInteractionProperties extends BlockInteraction
     private static final Integer DEFAULT_LIMIT_PER_REQUEST = 10;
     private static final Integer DEFAULT_RETRIES_PER_REQUEST = 3;
 
-    private @Getter @Setter @NotNull Integer limitPerRequest;
-    private @Getter @Setter @NotNull Integer retriesPerRequest;
+    private @Setter @Nullable Integer limitPerRequest;
+    private @Setter @Nullable Integer retriesPerRequest;
 
     public HederaMirrorNodeBlockInteractionProperties(
             Integer limitPerRequest, Integer retriesPerRequest) {
@@ -26,5 +27,15 @@ public class HederaMirrorNodeBlockInteractionProperties extends BlockInteraction
 
     public HederaMirrorNodeBlockInteractionProperties() {
         this(DEFAULT_LIMIT_PER_REQUEST, DEFAULT_RETRIES_PER_REQUEST);
+    }
+
+    @Override
+    public Optional<Integer> getLimitPerRequest() {
+        return Optional.ofNullable(limitPerRequest);
+    }
+
+    @Override
+    public Optional<Integer> getRetriesPerRequest() {
+        return Optional.ofNullable(retriesPerRequest);
     }
 }

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/subscription/block/BlockSubscriptionProperties.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/subscription/block/BlockSubscriptionProperties.java
@@ -1,15 +1,18 @@
 package io.naryo.infrastructure.configuration.source.env.model.node.subscription.block;
 
 import java.math.BigInteger;
+import java.util.Optional;
 
+import io.naryo.application.configuration.source.model.node.subscription.BlockSubscriptionDescriptor;
 import io.naryo.domain.node.subscription.SubscriptionStrategy;
 import io.naryo.domain.node.subscription.block.method.BlockSubscriptionMethod;
 import io.naryo.infrastructure.configuration.source.env.model.node.subscription.SubscriptionProperties;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
-public abstract class BlockSubscriptionProperties extends SubscriptionProperties {
+public abstract class BlockSubscriptionProperties extends SubscriptionProperties implements BlockSubscriptionDescriptor {
 
     private static final BigInteger DEFAULT_INITIAL_BLOCK = BigInteger.valueOf(-1);
     private static final BigInteger DEFAULT_CONFIRMATION_BLOCKS = BigInteger.valueOf(12);
@@ -19,12 +22,12 @@ public abstract class BlockSubscriptionProperties extends SubscriptionProperties
     private static final BigInteger DEFAULT_SYNC_BLOCK_LIMIT = BigInteger.valueOf(20000);
 
     private final @Getter @NotNull BlockSubscriptionMethod method;
-    private @Getter @Setter @NotNull BigInteger initialBlock;
-    private @Getter @Setter @NotNull BigInteger confirmationBlocks;
-    private @Getter @Setter @NotNull BigInteger missingTxRetryBlocks;
-    private @Getter @Setter @NotNull BigInteger eventInvalidationBlockThreshold;
-    private @Getter @Setter @NotNull BigInteger replayBlockOffset;
-    private @Getter @Setter @NotNull BigInteger syncBlockLimit;
+    private @Setter @Nullable BigInteger initialBlock;
+    private @Setter @Nullable BigInteger confirmationBlocks;
+    private @Setter @Nullable BigInteger missingTxRetryBlocks;
+    private @Setter @Nullable BigInteger eventInvalidationBlockThreshold;
+    private @Setter @Nullable BigInteger replayBlockOffset;
+    private @Setter @Nullable BigInteger syncBlockLimit;
 
     public BlockSubscriptionProperties(
             BlockSubscriptionMethod method,
@@ -50,5 +53,35 @@ public abstract class BlockSubscriptionProperties extends SubscriptionProperties
         this.replayBlockOffset =
                 replayBlockOffset != null ? replayBlockOffset : DEFAULT_REPLAY_BLOCK_OFFSET;
         this.syncBlockLimit = syncBlockLimit != null ? syncBlockLimit : DEFAULT_SYNC_BLOCK_LIMIT;
+    }
+
+    @Override
+    public Optional<BigInteger> getInitialBlock() {
+        return Optional.ofNullable(initialBlock);
+    }
+
+    @Override
+    public Optional<BigInteger> getConfirmationBlocks() {
+        return Optional.ofNullable(confirmationBlocks);
+    }
+
+    @Override
+    public Optional<BigInteger> getMissingTxRetryBlocks() {
+        return Optional.ofNullable(missingTxRetryBlocks);
+    }
+
+    @Override
+    public Optional<BigInteger> getEventInvalidationBlockThreshold() {
+        return Optional.ofNullable(eventInvalidationBlockThreshold);
+    }
+
+    @Override
+    public Optional<BigInteger> getReplayBlockOffset() {
+        return Optional.ofNullable(replayBlockOffset);
+    }
+
+    @Override
+    public Optional<BigInteger> getSyncBlockLimit() {
+        return Optional.ofNullable(syncBlockLimit);
     }
 }

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/subscription/block/PollBlockSubscriptionProperties.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/node/subscription/block/PollBlockSubscriptionProperties.java
@@ -2,6 +2,7 @@ package io.naryo.infrastructure.configuration.source.env.model.node.subscription
 
 import java.math.BigInteger;
 import java.time.Duration;
+import java.util.Optional;
 
 import io.naryo.application.configuration.source.model.node.subscription.PollBlockSubscriptionDescriptor;
 import io.naryo.domain.node.subscription.block.method.BlockSubscriptionMethod;
@@ -14,7 +15,7 @@ public final class PollBlockSubscriptionProperties extends BlockSubscriptionProp
 
     private static final Duration DEFAULT_INTERVAL = Duration.ofSeconds(5);
 
-    private @Getter @Setter @NotNull Duration interval;
+    private @Setter @NotNull Duration interval;
 
     public PollBlockSubscriptionProperties(
             BigInteger initialBlock,
@@ -33,5 +34,10 @@ public final class PollBlockSubscriptionProperties extends BlockSubscriptionProp
                 replayBlockOffset,
                 syncBlockLimit);
         this.interval = interval != null ? interval : DEFAULT_INTERVAL;
+    }
+
+    @Override
+    public Optional<Duration> getInterval() {
+        return Optional.ofNullable(interval);
     }
 }


### PR DESCRIPTION
Inside Node domain:

- Add `Optional<>` to descriptors' `getters` to allow partial configurations
- Fix descriptors' `merge` methods to manage partial configurations
- Fix descriptors' `setter` methods to avoid error-prone casting
- Adapt `DefaultNodeConfigurationManager` to use the new fields

Affected modules:
- **new-core**
- **spring-core**