### PR TITLE
chore (persistence-mongo): remove unnecessary collection name

### DIFF
--- a/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/broadcaster/target/AllBroadcasterTargetDocument.java
+++ b/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/broadcaster/target/AllBroadcasterTargetDocument.java
@@ -4,7 +4,7 @@ import io.naryo.application.configuration.source.model.broadcaster.target.AllBro
 import org.springframework.data.annotation.TypeAlias;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-@Document(collection = "broadcasters")
+@Document
 @TypeAlias("all_broadcaster_targets")
 public class AllBroadcasterTargetDocument extends BroadcasterTargetDocument
         implements AllBroadcasterTargetDescriptor {

--- a/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/broadcaster/target/BlockBroadcasterTargetDocument.java
+++ b/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/broadcaster/target/BlockBroadcasterTargetDocument.java
@@ -4,7 +4,7 @@ import io.naryo.application.configuration.source.model.broadcaster.target.BlockB
 import org.springframework.data.annotation.TypeAlias;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-@Document(collection = "broadcasters")
+@Document
 @TypeAlias("block_broadcaster_targets")
 public class BlockBroadcasterTargetDocument extends BroadcasterTargetDocument
         implements BlockBroadcasterTargetDescriptor {

--- a/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/broadcaster/target/ContractEventBroadcasterTargetDocument.java
+++ b/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/broadcaster/target/ContractEventBroadcasterTargetDocument.java
@@ -4,7 +4,7 @@ import io.naryo.application.configuration.source.model.broadcaster.target.Contra
 import org.springframework.data.annotation.TypeAlias;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-@Document(collection = "broadcasters")
+@Document
 @TypeAlias("contract_event_broadcaster_targets")
 public class ContractEventBroadcasterTargetDocument extends BroadcasterTargetDocument
         implements ContractEventBroadcasterTargetDescriptor {

--- a/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/broadcaster/target/FilterBroadcasterTargetDocument.java
+++ b/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/broadcaster/target/FilterBroadcasterTargetDocument.java
@@ -10,7 +10,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 
 import static io.naryo.application.common.util.MergeUtil.mergeValues;
 
-@Document(collection = "broadcasters")
+@Document
 @TypeAlias("filter_broadcaster_targets")
 public class FilterBroadcasterTargetDocument extends BroadcasterTargetDocument
         implements FilterBroadcasterTargetDescriptor {

--- a/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/broadcaster/target/TransactionBroadcasterTargetDocument.java
+++ b/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/broadcaster/target/TransactionBroadcasterTargetDocument.java
@@ -4,7 +4,7 @@ import io.naryo.application.configuration.source.model.broadcaster.target.Transa
 import org.springframework.data.annotation.TypeAlias;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-@Document(collection = "broadcasters")
+@Document
 @TypeAlias("transaction_broadcaster_targets")
 public class TransactionBroadcasterTargetDocument extends BroadcasterTargetDocument
         implements TransactionBroadcasterTargetDescriptor {


### PR DESCRIPTION
This PR removes the collection name from several documents that already belong to that collection.