### PR TITLE
Chore: test fixtures for broadcaster domain

### DIFF
--- a/new-core/src/main/java/io/naryo/domain/configuration/broadcaster/http/HttpBroadcasterConfiguration.java
+++ b/new-core/src/main/java/io/naryo/domain/configuration/broadcaster/http/HttpBroadcasterConfiguration.java
@@ -1,4 +1,4 @@
-package io.naryo.infrastructure.broadcaster.http.configuration;
+package io.naryo.domain.configuration.broadcaster.http;
 
 import java.util.Objects;
 import java.util.UUID;

--- a/new-core/src/main/java/io/naryo/infrastructure/broadcaster/http/producer/HttpBroadcasterProducer.java
+++ b/new-core/src/main/java/io/naryo/infrastructure/broadcaster/http/producer/HttpBroadcasterProducer.java
@@ -9,8 +9,8 @@ import io.naryo.domain.broadcaster.Broadcaster;
 import io.naryo.domain.broadcaster.BroadcasterType;
 import io.naryo.domain.common.connection.endpoint.ConnectionEndpoint;
 import io.naryo.domain.configuration.broadcaster.BroadcasterConfiguration;
+import io.naryo.domain.configuration.broadcaster.http.HttpBroadcasterConfiguration;
 import io.naryo.domain.event.Event;
-import io.naryo.infrastructure.broadcaster.http.configuration.HttpBroadcasterConfiguration;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
 

--- a/new-core/src/test/java/io/naryo/infrastructure/broadcaster/http/configuration/HttpBroadcasterConfigurationTest.java
+++ b/new-core/src/test/java/io/naryo/infrastructure/broadcaster/http/configuration/HttpBroadcasterConfigurationTest.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import io.naryo.domain.common.connection.endpoint.ConnectionEndpoint;
 import io.naryo.domain.configuration.broadcaster.BroadcasterCache;
+import io.naryo.domain.configuration.broadcaster.http.HttpBroadcasterConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;

--- a/new-core/src/test/java/io/naryo/infrastructure/broadcaster/http/producer/HttpBroadcasterProducerTest.java
+++ b/new-core/src/test/java/io/naryo/infrastructure/broadcaster/http/producer/HttpBroadcasterProducerTest.java
@@ -8,7 +8,7 @@ import io.naryo.domain.broadcaster.Broadcaster;
 import io.naryo.domain.broadcaster.BroadcasterTarget;
 import io.naryo.domain.broadcaster.Destination;
 import io.naryo.domain.common.connection.endpoint.ConnectionEndpoint;
-import io.naryo.infrastructure.broadcaster.http.configuration.HttpBroadcasterConfiguration;
+import io.naryo.domain.configuration.broadcaster.http.HttpBroadcasterConfiguration;
 import okhttp3.Call;
 import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.Test;

--- a/new-core/src/testFixtures/java/io/naryo/domain/DomainBuilder.java
+++ b/new-core/src/testFixtures/java/io/naryo/domain/DomainBuilder.java
@@ -1,0 +1,7 @@
+package io.naryo.domain;
+
+public interface DomainBuilder<T extends DomainBuilder<T, Y>, Y> {
+    T self();
+
+    Y build();
+}

--- a/new-core/src/testFixtures/java/io/naryo/domain/broadcaster/BroadcasterBuilder.java
+++ b/new-core/src/testFixtures/java/io/naryo/domain/broadcaster/BroadcasterBuilder.java
@@ -1,0 +1,49 @@
+package io.naryo.domain.broadcaster;
+
+import java.util.UUID;
+
+import io.naryo.domain.DomainBuilder;
+import org.instancio.Instancio;
+
+public class BroadcasterBuilder implements DomainBuilder<BroadcasterBuilder, Broadcaster> {
+
+    private UUID id;
+    private BroadcasterTarget target;
+    private UUID configurationId;
+
+    @Override
+    public BroadcasterBuilder self() {
+        return this;
+    }
+
+    public Broadcaster build() {
+        return new Broadcaster(this.getId(), this.getTarget(), this.getConfigurationId());
+    }
+
+    public BroadcasterBuilder withId(UUID id) {
+        this.id = id;
+        return self();
+    }
+
+    public BroadcasterBuilder withTarget(BroadcasterTarget target) {
+        this.target = target;
+        return self();
+    }
+
+    public BroadcasterBuilder withConfigurationId(UUID configurationId) {
+        this.configurationId = configurationId;
+        return self();
+    }
+
+    protected UUID getId() {
+        return this.id == null ? UUID.randomUUID() : this.id;
+    }
+
+    protected BroadcasterTarget getTarget() {
+        return this.target == null ? Instancio.create(BroadcasterTarget.class) : this.target;
+    }
+
+    protected UUID getConfigurationId() {
+        return this.configurationId == null ? UUID.randomUUID() : this.configurationId;
+    }
+}

--- a/new-core/src/testFixtures/java/io/naryo/domain/broadcaster/target/AllBroadcasterTargetBuilder.java
+++ b/new-core/src/testFixtures/java/io/naryo/domain/broadcaster/target/AllBroadcasterTargetBuilder.java
@@ -1,0 +1,15 @@
+package io.naryo.domain.broadcaster.target;
+
+public class AllBroadcasterTargetBuilder
+        extends BroadcasterTargetBuilder<AllBroadcasterTargetBuilder, AllBroadcasterTarget> {
+
+    @Override
+    public AllBroadcasterTargetBuilder self() {
+        return this;
+    }
+
+    @Override
+    public AllBroadcasterTarget build() {
+        return new AllBroadcasterTarget(this.getDestination());
+    }
+}

--- a/new-core/src/testFixtures/java/io/naryo/domain/broadcaster/target/BlockBroadcasterTargetBuilder.java
+++ b/new-core/src/testFixtures/java/io/naryo/domain/broadcaster/target/BlockBroadcasterTargetBuilder.java
@@ -1,0 +1,14 @@
+package io.naryo.domain.broadcaster.target;
+
+public class BlockBroadcasterTargetBuilder
+        extends BroadcasterTargetBuilder<BlockBroadcasterTargetBuilder, BlockBroadcasterTarget> {
+    @Override
+    public BlockBroadcasterTargetBuilder self() {
+        return this;
+    }
+
+    @Override
+    public BlockBroadcasterTarget build() {
+        return new BlockBroadcasterTarget(this.getDestination());
+    }
+}

--- a/new-core/src/testFixtures/java/io/naryo/domain/broadcaster/target/BroadcasterTargetBuilder.java
+++ b/new-core/src/testFixtures/java/io/naryo/domain/broadcaster/target/BroadcasterTargetBuilder.java
@@ -2,7 +2,6 @@ package io.naryo.domain.broadcaster.target;
 
 import io.naryo.domain.DomainBuilder;
 import io.naryo.domain.broadcaster.BroadcasterTarget;
-import io.naryo.domain.broadcaster.BroadcasterTargetType;
 import io.naryo.domain.broadcaster.Destination;
 import org.instancio.Instancio;
 
@@ -10,19 +9,7 @@ public abstract class BroadcasterTargetBuilder<
                 T extends BroadcasterTargetBuilder<T, Y>, Y extends BroadcasterTarget>
         implements DomainBuilder<T, Y> {
 
-    private BroadcasterTargetType type;
     private Destination destination;
-
-    @Override
-    public abstract T self();
-
-    @Override
-    public abstract Y build();
-
-    public T withType(BroadcasterTargetType type) {
-        this.type = type;
-        return self();
-    }
 
     public T withDestination(Destination destination) {
         this.destination = destination;
@@ -31,9 +18,5 @@ public abstract class BroadcasterTargetBuilder<
 
     protected Destination getDestination() {
         return this.destination == null ? Instancio.create(Destination.class) : this.destination;
-    }
-
-    protected BroadcasterTargetType getType() {
-        return this.type == null ? Instancio.create(BroadcasterTargetType.class) : this.type;
     }
 }

--- a/new-core/src/testFixtures/java/io/naryo/domain/broadcaster/target/BroadcasterTargetBuilder.java
+++ b/new-core/src/testFixtures/java/io/naryo/domain/broadcaster/target/BroadcasterTargetBuilder.java
@@ -1,0 +1,39 @@
+package io.naryo.domain.broadcaster.target;
+
+import io.naryo.domain.DomainBuilder;
+import io.naryo.domain.broadcaster.BroadcasterTarget;
+import io.naryo.domain.broadcaster.BroadcasterTargetType;
+import io.naryo.domain.broadcaster.Destination;
+import org.instancio.Instancio;
+
+public abstract class BroadcasterTargetBuilder<
+                T extends BroadcasterTargetBuilder<T, Y>, Y extends BroadcasterTarget>
+        implements DomainBuilder<T, Y> {
+
+    private BroadcasterTargetType type;
+    private Destination destination;
+
+    @Override
+    public abstract T self();
+
+    @Override
+    public abstract Y build();
+
+    public T withType(BroadcasterTargetType type) {
+        this.type = type;
+        return self();
+    }
+
+    public T withDestination(Destination destination) {
+        this.destination = destination;
+        return self();
+    }
+
+    protected Destination getDestination() {
+        return this.destination == null ? Instancio.create(Destination.class) : this.destination;
+    }
+
+    protected BroadcasterTargetType getType() {
+        return this.type == null ? Instancio.create(BroadcasterTargetType.class) : this.type;
+    }
+}

--- a/new-core/src/testFixtures/java/io/naryo/domain/broadcaster/target/ContractEventBroadcasterTargetBuilder.java
+++ b/new-core/src/testFixtures/java/io/naryo/domain/broadcaster/target/ContractEventBroadcasterTargetBuilder.java
@@ -1,0 +1,15 @@
+package io.naryo.domain.broadcaster.target;
+
+public class ContractEventBroadcasterTargetBuilder
+        extends BroadcasterTargetBuilder<
+                ContractEventBroadcasterTargetBuilder, ContractEventBroadcasterTarget> {
+    @Override
+    public ContractEventBroadcasterTargetBuilder self() {
+        return this;
+    }
+
+    @Override
+    public ContractEventBroadcasterTarget build() {
+        return new ContractEventBroadcasterTarget(this.getDestination());
+    }
+}

--- a/new-core/src/testFixtures/java/io/naryo/domain/broadcaster/target/FilterEventBroadcasterTargetBuilder.java
+++ b/new-core/src/testFixtures/java/io/naryo/domain/broadcaster/target/FilterEventBroadcasterTargetBuilder.java
@@ -1,0 +1,29 @@
+package io.naryo.domain.broadcaster.target;
+
+import java.util.UUID;
+
+public class FilterEventBroadcasterTargetBuilder
+        extends BroadcasterTargetBuilder<
+                FilterEventBroadcasterTargetBuilder, FilterEventBroadcasterTarget> {
+
+    private UUID filterId;
+
+    @Override
+    public FilterEventBroadcasterTargetBuilder self() {
+        return this;
+    }
+
+    @Override
+    public FilterEventBroadcasterTarget build() {
+        return new FilterEventBroadcasterTarget(this.getDestination(), this.getFilterId());
+    }
+
+    public FilterEventBroadcasterTargetBuilder withFilterId(UUID filterId) {
+        this.filterId = filterId;
+        return this;
+    }
+
+    protected UUID getFilterId() {
+        return this.filterId == null ? UUID.randomUUID() : this.filterId;
+    }
+}

--- a/new-core/src/testFixtures/java/io/naryo/domain/broadcaster/target/TransactionBroadcasterTargetBuilder.java
+++ b/new-core/src/testFixtures/java/io/naryo/domain/broadcaster/target/TransactionBroadcasterTargetBuilder.java
@@ -1,0 +1,15 @@
+package io.naryo.domain.broadcaster.target;
+
+public class TransactionBroadcasterTargetBuilder
+        extends BroadcasterTargetBuilder<
+                TransactionBroadcasterTargetBuilder, TransactionBroadcasterTarget> {
+    @Override
+    public TransactionBroadcasterTargetBuilder self() {
+        return this;
+    }
+
+    @Override
+    public TransactionBroadcasterTarget build() {
+        return new TransactionBroadcasterTarget(this.getDestination());
+    }
+}

--- a/new-core/src/testFixtures/java/io/naryo/domain/configuration/BroadcasterConfigurationBuilder.java
+++ b/new-core/src/testFixtures/java/io/naryo/domain/configuration/BroadcasterConfigurationBuilder.java
@@ -1,0 +1,60 @@
+package io.naryo.domain.configuration;
+
+import java.util.UUID;
+
+import io.naryo.domain.DomainBuilder;
+import io.naryo.domain.broadcaster.BroadcasterType;
+import io.naryo.domain.configuration.broadcaster.BroadcasterCache;
+import io.naryo.domain.configuration.broadcaster.BroadcasterConfiguration;
+import org.instancio.Instancio;
+import org.instancio.InstancioApi;
+
+import static org.instancio.Select.field;
+
+public abstract class BroadcasterConfigurationBuilder<
+                T extends BroadcasterConfigurationBuilder<T, Y>, Y extends BroadcasterConfiguration>
+        implements DomainBuilder<T, Y> {
+
+    private UUID id;
+    private BroadcasterType type;
+    private BroadcasterCache cache;
+
+    @Override
+    public abstract T self();
+
+    @Override
+    public abstract Y build();
+
+    public T withId(UUID id) {
+        this.id = id;
+        return self();
+    }
+
+    public T withType(BroadcasterType type) {
+        this.type = type;
+        return self();
+    }
+
+    public T withCache(BroadcasterCache cache) {
+        this.cache = cache;
+        return self();
+    }
+
+    protected UUID getId() {
+        return this.id == null ? UUID.randomUUID() : this.id;
+    }
+
+    protected BroadcasterType getType() {
+        return this.type == null ? Instancio.create(BroadcasterType.class) : this.type;
+    }
+
+    protected BroadcasterCache getCache() {
+        return this.cache == null ? Instancio.create(BroadcasterCache.class) : this.cache;
+    }
+
+    protected InstancioApi<Y> buildBase(InstancioApi<Y> builder) {
+        return builder.set(field(BroadcasterConfiguration::getId), this.getId())
+                .set(field(BroadcasterConfiguration::getType), this.getType())
+                .set(field(BroadcasterConfiguration::getCache), this.getCache());
+    }
+}

--- a/new-core/src/testFixtures/java/io/naryo/domain/configuration/BroadcasterConfigurationBuilder.java
+++ b/new-core/src/testFixtures/java/io/naryo/domain/configuration/BroadcasterConfigurationBuilder.java
@@ -3,20 +3,15 @@ package io.naryo.domain.configuration;
 import java.util.UUID;
 
 import io.naryo.domain.DomainBuilder;
-import io.naryo.domain.broadcaster.BroadcasterType;
 import io.naryo.domain.configuration.broadcaster.BroadcasterCache;
 import io.naryo.domain.configuration.broadcaster.BroadcasterConfiguration;
 import org.instancio.Instancio;
-import org.instancio.InstancioApi;
-
-import static org.instancio.Select.field;
 
 public abstract class BroadcasterConfigurationBuilder<
                 T extends BroadcasterConfigurationBuilder<T, Y>, Y extends BroadcasterConfiguration>
         implements DomainBuilder<T, Y> {
 
     private UUID id;
-    private BroadcasterType type;
     private BroadcasterCache cache;
 
     @Override
@@ -30,11 +25,6 @@ public abstract class BroadcasterConfigurationBuilder<
         return self();
     }
 
-    public T withType(BroadcasterType type) {
-        this.type = type;
-        return self();
-    }
-
     public T withCache(BroadcasterCache cache) {
         this.cache = cache;
         return self();
@@ -44,17 +34,7 @@ public abstract class BroadcasterConfigurationBuilder<
         return this.id == null ? UUID.randomUUID() : this.id;
     }
 
-    protected BroadcasterType getType() {
-        return this.type == null ? Instancio.create(BroadcasterType.class) : this.type;
-    }
-
     protected BroadcasterCache getCache() {
         return this.cache == null ? Instancio.create(BroadcasterCache.class) : this.cache;
-    }
-
-    protected InstancioApi<Y> buildBase(InstancioApi<Y> builder) {
-        return builder.set(field(BroadcasterConfiguration::getId), this.getId())
-                .set(field(BroadcasterConfiguration::getType), this.getType())
-                .set(field(BroadcasterConfiguration::getCache), this.getCache());
     }
 }

--- a/new-core/src/testFixtures/java/io/naryo/domain/configuration/http/HttpBroadcasterConfigurationBuilder.java
+++ b/new-core/src/testFixtures/java/io/naryo/domain/configuration/http/HttpBroadcasterConfigurationBuilder.java
@@ -1,8 +1,8 @@
-package io.naryo.domain.infraestructure;
+package io.naryo.domain.configuration.http;
 
 import io.naryo.domain.common.connection.endpoint.ConnectionEndpoint;
 import io.naryo.domain.configuration.BroadcasterConfigurationBuilder;
-import io.naryo.infrastructure.broadcaster.http.configuration.HttpBroadcasterConfiguration;
+import io.naryo.domain.configuration.broadcaster.http.HttpBroadcasterConfiguration;
 import org.instancio.Instancio;
 
 public class HttpBroadcasterConfigurationBuilder

--- a/new-core/src/testFixtures/java/io/naryo/domain/filter/FilterBuilder.java
+++ b/new-core/src/testFixtures/java/io/naryo/domain/filter/FilterBuilder.java
@@ -2,12 +2,14 @@ package io.naryo.domain.filter;
 
 import java.util.UUID;
 
+import io.naryo.domain.DomainBuilder;
 import org.instancio.Instancio;
 import org.instancio.InstancioApi;
 
 import static org.instancio.Select.field;
 
-public abstract class FilterBuilder<T, Y extends Filter> {
+public abstract class FilterBuilder<T extends FilterBuilder<T, Y>, Y extends Filter>
+        implements DomainBuilder<T, Y> {
 
     private UUID id;
     private FilterName name;

--- a/new-core/src/testFixtures/java/io/naryo/domain/filter/FilterBuilder.java
+++ b/new-core/src/testFixtures/java/io/naryo/domain/filter/FilterBuilder.java
@@ -4,9 +4,6 @@ import java.util.UUID;
 
 import io.naryo.domain.DomainBuilder;
 import org.instancio.Instancio;
-import org.instancio.InstancioApi;
-
-import static org.instancio.Select.field;
 
 public abstract class FilterBuilder<T extends FilterBuilder<T, Y>, Y extends Filter>
         implements DomainBuilder<T, Y> {
@@ -32,13 +29,6 @@ public abstract class FilterBuilder<T extends FilterBuilder<T, Y>, Y extends Fil
     public T withNodeId(UUID nodeId) {
         this.nodeId = nodeId;
         return self();
-    }
-
-    protected InstancioApi<Y> buildBase(InstancioApi<Y> builder, FilterType type) {
-        return builder.set(field(Filter::getId), this.getId())
-                .set(field(Filter::getName), this.getName())
-                .set(field(Filter::getNodeId), this.getNodeId())
-                .set(field(Filter::getType), type);
     }
 
     protected UUID getId() {

--- a/new-core/src/testFixtures/java/io/naryo/domain/filter/event/BlockActiveSyncStateBuilder.java
+++ b/new-core/src/testFixtures/java/io/naryo/domain/filter/event/BlockActiveSyncStateBuilder.java
@@ -1,14 +1,22 @@
 package io.naryo.domain.filter.event;
 
+import io.naryo.domain.DomainBuilder;
 import io.naryo.domain.common.NonNegativeBlockNumber;
 import io.naryo.domain.filter.event.sync.block.BlockActiveSyncState;
 import org.instancio.Instancio;
 
-public class BlockActiveSyncStateBuilder {
+public class BlockActiveSyncStateBuilder
+        implements DomainBuilder<BlockActiveSyncStateBuilder, BlockActiveSyncState> {
 
     private NonNegativeBlockNumber initialBlock;
     private NonNegativeBlockNumber lastBlockProcessed;
 
+    @Override
+    public BlockActiveSyncStateBuilder self() {
+        return this;
+    }
+
+    @Override
     public BlockActiveSyncState build() {
         return new BlockActiveSyncState(this.getInitialBlock(), this.getLastBlockProcessed());
     }

--- a/new-core/src/testFixtures/java/io/naryo/domain/filter/event/EventFilterBuilder.java
+++ b/new-core/src/testFixtures/java/io/naryo/domain/filter/event/EventFilterBuilder.java
@@ -6,7 +6,8 @@ import io.naryo.domain.common.event.ContractEventStatus;
 import io.naryo.domain.filter.FilterBuilder;
 import org.instancio.Instancio;
 
-public abstract class EventFilterBuilder<T, Y extends EventFilter> extends FilterBuilder<T, Y> {
+public abstract class EventFilterBuilder<T extends EventFilterBuilder<T, Y>, Y extends EventFilter>
+        extends FilterBuilder<T, Y> {
 
     private EventFilterSpecification specification;
     private Set<ContractEventStatus> statuses;

--- a/new-core/src/testFixtures/java/io/naryo/domain/filter/event/EventFilterSpecificationBuilder.java
+++ b/new-core/src/testFixtures/java/io/naryo/domain/filter/event/EventFilterSpecificationBuilder.java
@@ -2,16 +2,24 @@ package io.naryo.domain.filter.event;
 
 import java.util.Set;
 
+import io.naryo.domain.DomainBuilder;
 import io.naryo.domain.common.event.EventName;
 import io.naryo.domain.filter.event.parameterdefinition.AddressParameterDefinitionBuilder;
 import org.instancio.Instancio;
 
-public class EventFilterSpecificationBuilder {
+public class EventFilterSpecificationBuilder
+        implements DomainBuilder<EventFilterSpecificationBuilder, EventFilterSpecification> {
 
     private EventName eventName;
     private CorrelationId correlationId;
     private Set<ParameterDefinition> parameters;
 
+    @Override
+    public EventFilterSpecificationBuilder self() {
+        return this;
+    }
+
+    @Override
     public EventFilterSpecification build() {
         return new EventFilterSpecification(
                 this.getEventName(), this.getCorrelationId(), this.getParameters());

--- a/new-core/src/testFixtures/java/io/naryo/domain/filter/event/EventFilterVisibilityConfigurationBuilder.java
+++ b/new-core/src/testFixtures/java/io/naryo/domain/filter/event/EventFilterVisibilityConfigurationBuilder.java
@@ -1,12 +1,21 @@
 package io.naryo.domain.filter.event;
 
+import io.naryo.domain.DomainBuilder;
 import org.instancio.Instancio;
 
-public class EventFilterVisibilityConfigurationBuilder {
+public class EventFilterVisibilityConfigurationBuilder
+        implements DomainBuilder<
+                EventFilterVisibilityConfigurationBuilder, EventFilterVisibilityConfiguration> {
 
     private Boolean visible;
     private String privacyGroupId;
 
+    @Override
+    public EventFilterVisibilityConfigurationBuilder self() {
+        return this;
+    }
+
+    @Override
     public EventFilterVisibilityConfiguration build() {
         return this.isVisible()
                 ? EventFilterVisibilityConfiguration.visible()

--- a/new-core/src/testFixtures/java/io/naryo/domain/infraestructure/HttpBroadcasterConfigurationBuilder.java
+++ b/new-core/src/testFixtures/java/io/naryo/domain/infraestructure/HttpBroadcasterConfigurationBuilder.java
@@ -1,0 +1,32 @@
+package io.naryo.domain.infraestructure;
+
+import io.naryo.domain.common.connection.endpoint.ConnectionEndpoint;
+import io.naryo.domain.configuration.BroadcasterConfigurationBuilder;
+import io.naryo.infrastructure.broadcaster.http.configuration.HttpBroadcasterConfiguration;
+import org.instancio.Instancio;
+
+public class HttpBroadcasterConfigurationBuilder
+        extends BroadcasterConfigurationBuilder<
+                HttpBroadcasterConfigurationBuilder, HttpBroadcasterConfiguration> {
+
+    private ConnectionEndpoint endpoint;
+
+    @Override
+    public HttpBroadcasterConfigurationBuilder self() {
+        return this;
+    }
+
+    @Override
+    public HttpBroadcasterConfiguration build() {
+        return new HttpBroadcasterConfiguration(getId(), getCache(), getEndpoint());
+    }
+
+    public HttpBroadcasterConfigurationBuilder withEndpoint(ConnectionEndpoint endpoint) {
+        this.endpoint = endpoint;
+        return self();
+    }
+
+    protected ConnectionEndpoint getEndpoint() {
+        return this.endpoint == null ? Instancio.create(ConnectionEndpoint.class) : this.endpoint;
+    }
+}

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/beans/broadcaster/http/BroadcasterInitializer.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/beans/broadcaster/http/BroadcasterInitializer.java
@@ -10,7 +10,7 @@ import io.naryo.application.configuration.source.definition.registry.Configurati
 import io.naryo.application.configuration.source.model.broadcaster.configuration.BroadcasterConfigurationDescriptor;
 import io.naryo.domain.common.connection.endpoint.ConnectionEndpoint;
 import io.naryo.domain.configuration.broadcaster.BroadcasterCache;
-import io.naryo.infrastructure.broadcaster.http.configuration.HttpBroadcasterConfiguration;
+import io.naryo.domain.configuration.broadcaster.http.HttpBroadcasterConfiguration;
 import io.naryo.infrastructure.configuration.beans.env.EnvironmentInitializer;
 import org.springframework.stereotype.Component;
 


### PR DESCRIPTION
This pull request introduces a set of builder classes for the creation of domain objects for Broadcaster domain. The changes include the addition of a generic `DomainBuilder` interface and dedicated builders for broadcaster targets and broadcaster configurations, as well as small adaptations in existing Filter builder classes to implement the new interface. 