### PR TITLE
chore: Tests for broadcaster descriptors

### DIFF
--- a/new-core/src/main/java/io/naryo/application/configuration/source/model/broadcaster/configuration/BroadcasterConfigurationDescriptor.java
+++ b/new-core/src/main/java/io/naryo/application/configuration/source/model/broadcaster/configuration/BroadcasterConfigurationDescriptor.java
@@ -8,8 +8,7 @@ import io.naryo.application.configuration.source.definition.ConfigurationSchema;
 import io.naryo.application.configuration.source.model.MergeableDescriptor;
 import io.naryo.domain.broadcaster.BroadcasterType;
 
-import static io.naryo.application.common.util.MergeUtil.mergeDescriptors;
-import static io.naryo.application.common.util.MergeUtil.mergeOptionals;
+import static io.naryo.application.common.util.MergeUtil.*;
 
 public interface BroadcasterConfigurationDescriptor
         extends MergeableDescriptor<BroadcasterConfigurationDescriptor> {
@@ -20,7 +19,7 @@ public interface BroadcasterConfigurationDescriptor
 
     <T extends BroadcasterCacheConfigurationDescriptor> Optional<T> getCache();
 
-    Optional<Map<String, Object>> getAdditionalProperties();
+    Map<String, Object> getAdditionalProperties();
 
     <T extends ConfigurationSchema> Optional<T> getPropertiesSchema();
 
@@ -32,8 +31,12 @@ public interface BroadcasterConfigurationDescriptor
 
     @Override
     default BroadcasterConfigurationDescriptor merge(BroadcasterConfigurationDescriptor other) {
+        if (!this.getType().getName().equals(other.getType().getName())) {
+            return this;
+        }
+
         mergeDescriptors(this::setCache, this.getCache(), other.getCache());
-        mergeOptionals(
+        mergeMaps(
                 this::setAdditionalProperties,
                 this.getAdditionalProperties(),
                 other.getAdditionalProperties());

--- a/new-core/src/test/java/io/naryo/application/common/util/MergeUtilTest.java
+++ b/new-core/src/test/java/io/naryo/application/common/util/MergeUtilTest.java
@@ -9,6 +9,7 @@ import jakarta.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
+import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -98,6 +99,47 @@ class MergeUtilTest {
         MergeUtil.mergeCollections(testSetter, original, other);
 
         assertNull(result.get(), "Setter should not be called when original is not empty");
+    }
+
+    @Test
+    void testMergeMaps_bothEmpty() {
+        Map<String, String> original = new HashMap<>();
+        Map<String, String> other = new HashMap<>();
+
+        AtomicReference<Map<String, String>> result = new AtomicReference<>();
+        Consumer<Map<String, String>> testSetter = result::set;
+
+        MergeUtil.mergeMaps(testSetter, original, other);
+
+        assertNull(result.get(), "Setter should not be called when both maps are empty");
+    }
+
+    @Test
+    void testMergeMaps_originalEmptyOtherNotEmpty() {
+        Map<String, String> original = new HashMap<>();
+        Map<String, String> other = Instancio.createMap(String.class, String.class);
+
+        AtomicReference<Map<String, String>> result = new AtomicReference<>();
+        Consumer<Map<String, String>> testSetter = result::set;
+
+        MergeUtil.mergeMaps(testSetter, original, other);
+
+        assertEquals(other, result.get(), "Setter should be called with the value from 'other'");
+    }
+
+    @Test
+    void testMergeMaps_originalNotEmptyOtherEmpty() {
+        Map<String, String> original = Instancio.createMap(String.class, String.class);
+        Map<String, String> other = new HashMap<>();
+
+        AtomicReference<Map<String, String>> result = new AtomicReference<>();
+        Consumer<Map<String, String>> testSetter = result::set;
+
+        MergeUtil.mergeMaps(testSetter, original, other);
+
+        assertNull(
+                result.get(),
+                "Setter should not be called when original is not empty and other is empty");
     }
 
     @Test

--- a/new-core/src/test/java/io/naryo/application/configuration/source/model/broadcaster/BroadcasterDescriptorTest.java
+++ b/new-core/src/test/java/io/naryo/application/configuration/source/model/broadcaster/BroadcasterDescriptorTest.java
@@ -1,0 +1,94 @@
+package io.naryo.application.configuration.source.model.broadcaster;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import io.naryo.application.configuration.source.model.DescriptorTestUuidArgumentsProvider;
+import io.naryo.application.configuration.source.model.broadcaster.target.AllBroadcasterTargetDescriptorTest;
+import io.naryo.application.configuration.source.model.broadcaster.target.BroadcasterTargetDescriptor;
+import lombok.Getter;
+import lombok.Setter;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class BroadcasterDescriptorTest {
+
+    @ParameterizedTest
+    @ArgumentsSource(DescriptorTestUuidArgumentsProvider.class)
+    void testMerge_configurationId(
+            UUID originalConfigurationId, UUID otherConfigurationId, UUID expectedConfigurationId) {
+        BroadcasterDescriptor original = new DummyBroadcasterDescriptor();
+        original.setConfigurationId(originalConfigurationId);
+        BroadcasterDescriptor other = new DummyBroadcasterDescriptor();
+        other.setConfigurationId(otherConfigurationId);
+
+        BroadcasterDescriptor result = original.merge(other);
+
+        assertEquals(
+                Optional.ofNullable(expectedConfigurationId),
+                result.getConfigurationId(),
+                "Should merge the configurationId");
+    }
+
+    @ParameterizedTest
+    @MethodSource("targetParameters")
+    void testMerge_target(
+            BroadcasterTargetDescriptor originalTarget,
+            BroadcasterTargetDescriptor otherTarget,
+            BroadcasterTargetDescriptor expectedTarget) {
+        BroadcasterDescriptor original = new DummyBroadcasterDescriptor();
+        original.setTarget(originalTarget);
+        BroadcasterDescriptor other = new DummyBroadcasterDescriptor();
+        other.setTarget(otherTarget);
+
+        BroadcasterDescriptor result = original.merge(other);
+
+        assertEquals(
+                Optional.ofNullable(expectedTarget), result.getTarget(), "Should merge the target");
+    }
+
+    private static Stream<Arguments> targetParameters() {
+        BroadcasterTargetDescriptor original =
+                Instancio.create(
+                        AllBroadcasterTargetDescriptorTest.DummyAllBroadcasterTargetDescriptor
+                                .class);
+        BroadcasterTargetDescriptor other =
+                Instancio.create(
+                        AllBroadcasterTargetDescriptorTest.DummyAllBroadcasterTargetDescriptor
+                                .class);
+
+        return Stream.of(
+                Arguments.of(original, other, original),
+                Arguments.of(null, other, other),
+                Arguments.of(null, null, null));
+    }
+
+    public static class DummyBroadcasterDescriptor implements BroadcasterDescriptor {
+        private final @Getter UUID id;
+        private @Setter UUID configurationId;
+        private @Setter BroadcasterTargetDescriptor target;
+
+        protected DummyBroadcasterDescriptor() {
+            this.id = UUID.randomUUID();
+        }
+
+        @Override
+        public Optional<UUID> getConfigurationId() {
+            return Optional.ofNullable(configurationId);
+        }
+
+        @Override
+        public Optional<BroadcasterTargetDescriptor> getTarget() {
+            return Optional.ofNullable(target);
+        }
+    }
+}

--- a/new-core/src/test/java/io/naryo/application/configuration/source/model/broadcaster/configuration/BroadcasterCacheConfigurationDescriptorTest.java
+++ b/new-core/src/test/java/io/naryo/application/configuration/source/model/broadcaster/configuration/BroadcasterCacheConfigurationDescriptorTest.java
@@ -1,0 +1,40 @@
+package io.naryo.application.configuration.source.model.broadcaster.configuration;
+
+import java.time.Duration;
+
+import lombok.Getter;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class BroadcasterCacheConfigurationDescriptorTest {
+
+    @Test
+    void testMerge_expirationTime() {
+        BroadcasterCacheConfigurationDescriptor original =
+                new DummyBroadcasterCacheConfigurationDescriptor();
+        BroadcasterCacheConfigurationDescriptor other =
+                new DummyBroadcasterCacheConfigurationDescriptor();
+
+        BroadcasterCacheConfigurationDescriptor result = original.merge(other);
+
+        assertEquals(
+                original,
+                result,
+                "Should return the original BroadcasterCacheConfigurationDescriptor when merging");
+    }
+
+    @Getter
+    public static class DummyBroadcasterCacheConfigurationDescriptor
+            implements BroadcasterCacheConfigurationDescriptor {
+        private final Duration expirationTime;
+
+        public DummyBroadcasterCacheConfigurationDescriptor() {
+            this.expirationTime = Instancio.create(Duration.class);
+        }
+    }
+}

--- a/new-core/src/test/java/io/naryo/application/configuration/source/model/broadcaster/configuration/BroadcasterConfigurationDescriptorTest.java
+++ b/new-core/src/test/java/io/naryo/application/configuration/source/model/broadcaster/configuration/BroadcasterConfigurationDescriptorTest.java
@@ -1,0 +1,167 @@
+package io.naryo.application.configuration.source.model.broadcaster.configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import io.naryo.application.configuration.source.definition.ConfigurationSchema;
+import io.naryo.domain.broadcaster.BroadcasterType;
+import lombok.Getter;
+import lombok.Setter;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class BroadcasterConfigurationDescriptorTest {
+
+    @Test
+    void testMerge_differentType() {
+        BroadcasterConfigurationDescriptor original =
+                new DummyBroadcasterConfigurationDescriptor("original");
+        BroadcasterConfigurationDescriptor other =
+                new DummyBroadcasterConfigurationDescriptor("other");
+
+        BroadcasterConfigurationDescriptor result = original.merge(other);
+
+        assertEquals(
+                original,
+                result,
+                "Should return the original BroadcasterConfigurationDescriptor when merging with a different Type");
+    }
+
+    @ParameterizedTest
+    @MethodSource("cacheParameters")
+    void testMerge_cache(
+            BroadcasterCacheConfigurationDescriptor originalCache,
+            BroadcasterCacheConfigurationDescriptor otherCache,
+            BroadcasterCacheConfigurationDescriptor expectedCache) {
+        BroadcasterConfigurationDescriptor original = new DummyBroadcasterConfigurationDescriptor();
+        original.setCache(originalCache);
+        BroadcasterConfigurationDescriptor other = new DummyBroadcasterConfigurationDescriptor();
+        other.setCache(otherCache);
+
+        BroadcasterConfigurationDescriptor result = original.merge(other);
+
+        assertEquals(
+                Optional.ofNullable(expectedCache), result.getCache(), "Should merge the cache");
+    }
+
+    private static Stream<Arguments> cacheParameters() {
+        BroadcasterCacheConfigurationDescriptor original =
+                Instancio.create(
+                        BroadcasterCacheConfigurationDescriptorTest
+                                .DummyBroadcasterCacheConfigurationDescriptor.class);
+        BroadcasterCacheConfigurationDescriptor other =
+                Instancio.create(
+                        BroadcasterCacheConfigurationDescriptorTest
+                                .DummyBroadcasterCacheConfigurationDescriptor.class);
+
+        return Stream.of(
+                Arguments.of(original, other, original),
+                Arguments.of(original, null, original),
+                Arguments.of(null, other, other),
+                Arguments.of(null, null, null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("additionalPropertiesParameters")
+    void testMerge_additionalProperties(
+            Map<String, Object> originalAdditionalProperties,
+            Map<String, Object> otherAdditionalProperties,
+            Map<String, Object> expectedAdditionalProperties) {
+        BroadcasterConfigurationDescriptor original = new DummyBroadcasterConfigurationDescriptor();
+        original.setAdditionalProperties(originalAdditionalProperties);
+        BroadcasterConfigurationDescriptor other = new DummyBroadcasterConfigurationDescriptor();
+        other.setAdditionalProperties(otherAdditionalProperties);
+
+        BroadcasterConfigurationDescriptor result = original.merge(other);
+
+        assertEquals(
+                expectedAdditionalProperties,
+                result.getAdditionalProperties(),
+                "Should merge the additional properties");
+    }
+
+    private static Stream<Arguments> additionalPropertiesParameters() {
+        Map<String, Object> empty = new HashMap<>();
+        Map<String, Object> filled = Instancio.createMap(String.class, Object.class);
+
+        return Stream.of(
+                Arguments.of(filled, filled, filled),
+                Arguments.of(filled, empty, filled),
+                Arguments.of(empty, filled, filled),
+                Arguments.of(empty, empty, empty));
+    }
+
+    @ParameterizedTest
+    @MethodSource("propertiesSchemaParameters")
+    void testMerge_propertiesSchema(
+            ConfigurationSchema originalPropertiesSchema,
+            ConfigurationSchema otherPropertiesSchema,
+            ConfigurationSchema expectedPropertiesSchema) {
+        BroadcasterConfigurationDescriptor original = new DummyBroadcasterConfigurationDescriptor();
+        original.setPropertiesSchema(originalPropertiesSchema);
+        BroadcasterConfigurationDescriptor other = new DummyBroadcasterConfigurationDescriptor();
+        other.setPropertiesSchema(otherPropertiesSchema);
+
+        BroadcasterConfigurationDescriptor result = original.merge(other);
+
+        assertEquals(
+                Optional.ofNullable(expectedPropertiesSchema),
+                result.getPropertiesSchema(),
+                "Should merge the properties schema");
+    }
+
+    private static Stream<Arguments> propertiesSchemaParameters() {
+        ConfigurationSchema original = Instancio.create(ConfigurationSchema.class);
+        ConfigurationSchema other = Instancio.create(ConfigurationSchema.class);
+
+        return Stream.of(
+                Arguments.of(original, other, original),
+                Arguments.of(original, null, original),
+                Arguments.of(null, other, other),
+                Arguments.of(null, null, null));
+    }
+
+    public static class DummyBroadcasterConfigurationDescriptor
+            implements BroadcasterConfigurationDescriptor {
+        private final @Getter UUID id;
+        private final @Getter BroadcasterType type;
+        private @Setter BroadcasterCacheConfigurationDescriptor cache;
+        private @Setter Map<String, Object> additionalProperties;
+        private @Setter ConfigurationSchema propertiesSchema;
+
+        protected DummyBroadcasterConfigurationDescriptor() {
+            this("type");
+        }
+
+        protected DummyBroadcasterConfigurationDescriptor(String type) {
+            this.id = UUID.randomUUID();
+            this.type = () -> type;
+        }
+
+        @Override
+        public Optional<BroadcasterCacheConfigurationDescriptor> getCache() {
+            return Optional.ofNullable(cache);
+        }
+
+        @Override
+        public Map<String, Object> getAdditionalProperties() {
+            return additionalProperties == null ? Map.of() : additionalProperties;
+        }
+
+        @Override
+        public Optional<ConfigurationSchema> getPropertiesSchema() {
+            return Optional.ofNullable(propertiesSchema);
+        }
+    }
+}

--- a/new-core/src/test/java/io/naryo/application/configuration/source/model/broadcaster/target/AllBroadcasterTargetDescriptorTest.java
+++ b/new-core/src/test/java/io/naryo/application/configuration/source/model/broadcaster/target/AllBroadcasterTargetDescriptorTest.java
@@ -1,0 +1,17 @@
+package io.naryo.application.configuration.source.model.broadcaster.target;
+
+import lombok.Setter;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AllBroadcasterTargetDescriptorTest extends BroadcasterTargetDescriptorTest {
+
+    protected BroadcasterTargetDescriptor getBroadcasterDescriptor() {
+        return new DummyAllBroadcasterTargetDescriptor();
+    }
+
+    @Setter
+    public static class DummyAllBroadcasterTargetDescriptor extends DummyBroadcasterTargetDescriptor
+            implements AllBroadcasterTargetDescriptor {}
+}

--- a/new-core/src/test/java/io/naryo/application/configuration/source/model/broadcaster/target/BlockBroadcasterTargetDescriptorTest.java
+++ b/new-core/src/test/java/io/naryo/application/configuration/source/model/broadcaster/target/BlockBroadcasterTargetDescriptorTest.java
@@ -1,0 +1,17 @@
+package io.naryo.application.configuration.source.model.broadcaster.target;
+
+import lombok.Setter;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class BlockBroadcasterTargetDescriptorTest extends BroadcasterTargetDescriptorTest {
+
+    protected BroadcasterTargetDescriptor getBroadcasterDescriptor() {
+        return new DummyBlockBroadcasterTargetDescriptor();
+    }
+
+    @Setter
+    public static class DummyBlockBroadcasterTargetDescriptor
+            extends DummyBroadcasterTargetDescriptor implements BlockBroadcasterTargetDescriptor {}
+}

--- a/new-core/src/test/java/io/naryo/application/configuration/source/model/broadcaster/target/BroadcasterTargetDescriptorTest.java
+++ b/new-core/src/test/java/io/naryo/application/configuration/source/model/broadcaster/target/BroadcasterTargetDescriptorTest.java
@@ -1,0 +1,73 @@
+package io.naryo.application.configuration.source.model.broadcaster.target;
+
+import java.util.Optional;
+
+import io.naryo.application.configuration.source.model.DescriptorTestStringArgumentsProvider;
+import io.naryo.domain.broadcaster.BroadcasterTargetType;
+import lombok.Setter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public abstract class BroadcasterTargetDescriptorTest {
+
+    protected abstract BroadcasterTargetDescriptor getBroadcasterDescriptor();
+
+    @Test
+    void testMerge_differentTargetType() {
+        BroadcasterTargetDescriptor original =
+                new DummyBroadcasterTargetDescriptor() {
+                    @Override
+                    public BroadcasterTargetType getType() {
+                        return BroadcasterTargetType.ALL;
+                    }
+                };
+        BroadcasterTargetDescriptor other =
+                new DummyBroadcasterTargetDescriptor() {
+                    @Override
+                    public BroadcasterTargetType getType() {
+                        return BroadcasterTargetType.FILTER;
+                    }
+                };
+
+        BroadcasterTargetDescriptor result = original.merge(other);
+
+        assertEquals(
+                original,
+                result,
+                "Should return the original BroadcasterTargetDescriptor when merging with a different BroadcasterTargetType");
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(DescriptorTestStringArgumentsProvider.class)
+    void testMerge_destination(
+            String originalDestination, String otherDestination, String expectedDestination) {
+        BroadcasterTargetDescriptor original = this.getBroadcasterDescriptor();
+        original.setDestination(originalDestination);
+        BroadcasterTargetDescriptor other = this.getBroadcasterDescriptor();
+        other.setDestination(otherDestination);
+
+        BroadcasterTargetDescriptor result = original.merge(other);
+
+        assertEquals(
+                Optional.ofNullable(expectedDestination),
+                result.getDestination(),
+                "Should merge the destination");
+    }
+
+    @Setter
+    public abstract static class DummyBroadcasterTargetDescriptor
+            implements BroadcasterTargetDescriptor {
+        private String destination;
+
+        @Override
+        public Optional<String> getDestination() {
+            return Optional.ofNullable(destination);
+        }
+    }
+}

--- a/new-core/src/test/java/io/naryo/application/configuration/source/model/broadcaster/target/ContractBroadcasterTargetDescriptorTest.java
+++ b/new-core/src/test/java/io/naryo/application/configuration/source/model/broadcaster/target/ContractBroadcasterTargetDescriptorTest.java
@@ -1,0 +1,18 @@
+package io.naryo.application.configuration.source.model.broadcaster.target;
+
+import lombok.Setter;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ContractBroadcasterTargetDescriptorTest extends BroadcasterTargetDescriptorTest {
+
+    protected BroadcasterTargetDescriptor getBroadcasterDescriptor() {
+        return new DummyContractBroadcasterTargetDescriptor();
+    }
+
+    @Setter
+    public static class DummyContractBroadcasterTargetDescriptor
+            extends DummyBroadcasterTargetDescriptor
+            implements ContractEventBroadcasterTargetDescriptor {}
+}

--- a/new-core/src/test/java/io/naryo/application/configuration/source/model/broadcaster/target/FilterBroadcasterTargetDescriptorTest.java
+++ b/new-core/src/test/java/io/naryo/application/configuration/source/model/broadcaster/target/FilterBroadcasterTargetDescriptorTest.java
@@ -1,0 +1,28 @@
+package io.naryo.application.configuration.source.model.broadcaster.target;
+
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class FilterBroadcasterTargetDescriptorTest extends BroadcasterTargetDescriptorTest {
+
+    protected BroadcasterTargetDescriptor getBroadcasterDescriptor() {
+        return new DummyFilterBroadcasterTargetDescriptor(UUID.randomUUID());
+    }
+
+    @Setter
+    @Getter
+    public static class DummyFilterBroadcasterTargetDescriptor
+            extends DummyBroadcasterTargetDescriptor implements FilterBroadcasterTargetDescriptor {
+        UUID filterId;
+
+        public DummyFilterBroadcasterTargetDescriptor(UUID filterId) {
+            super();
+            this.filterId = filterId;
+        }
+    }
+}

--- a/new-core/src/test/java/io/naryo/application/configuration/source/model/broadcaster/target/TransactionBroadcasterTargetDescriptorTest.java
+++ b/new-core/src/test/java/io/naryo/application/configuration/source/model/broadcaster/target/TransactionBroadcasterTargetDescriptorTest.java
@@ -1,0 +1,18 @@
+package io.naryo.application.configuration.source.model.broadcaster.target;
+
+import lombok.Setter;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class TransactionBroadcasterTargetDescriptorTest extends BroadcasterTargetDescriptorTest {
+
+    protected BroadcasterTargetDescriptor getBroadcasterDescriptor() {
+        return new DummyTransactionBroadcasterTargetDescriptor();
+    }
+
+    @Setter
+    public static class DummyTransactionBroadcasterTargetDescriptor
+            extends DummyBroadcasterTargetDescriptor
+            implements TransactionBroadcasterTargetDescriptor {}
+}

--- a/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/broadcaster/configuration/BroadcasterConfigurationDocument.java
+++ b/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/broadcaster/configuration/BroadcasterConfigurationDocument.java
@@ -1,9 +1,6 @@
 package io.naryo.infrastructure.configuration.persistence.document.broadcaster.configuration;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import com.mongodb.lang.Nullable;
@@ -40,7 +37,7 @@ public final class BroadcasterConfigurationDocument implements BroadcasterConfig
 
     @Override
     public BroadcasterType getType() {
-        return () -> this.type.toLowerCase();
+        return this.type::toLowerCase;
     }
 
     @Override
@@ -49,8 +46,8 @@ public final class BroadcasterConfigurationDocument implements BroadcasterConfig
     }
 
     @Override
-    public Optional<Map<String, Object>> getAdditionalProperties() {
-        return Optional.ofNullable(this.additionalProperties);
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties == null ? Map.of() : this.additionalProperties;
     }
 
     @Override

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/beans/broadcaster/http/BroadcasterInitializer.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/beans/broadcaster/http/BroadcasterInitializer.java
@@ -39,13 +39,13 @@ public final class BroadcasterInitializer implements EnvironmentInitializer {
                 HTTP_BROADCASTER_TYPE,
                 BroadcasterConfigurationDescriptor.class,
                 properties -> {
-                    Map<String, Object> props = valueOrNull(properties.getAdditionalProperties());
-                    Object raw = props != null ? props.get("endpoint") : null;
+                    Map<String, Object> props = properties.getAdditionalProperties();
+                    Object raw = props.isEmpty() ? null : props.get("endpoint");
                     HttpBroadcasterEndpoint endpoint;
 
                     if (raw instanceof HttpBroadcasterEndpoint typed) {
                         endpoint = typed;
-                    } else if (raw instanceof Map map) {
+                    } else if (raw instanceof Map<?, ?> map) {
                         endpoint = new HttpBroadcasterEndpoint((String) map.get("url"));
                     } else {
                         return null;

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/broadcaster/configuration/BroadcasterConfigurationEntryProperties.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/source/env/model/broadcaster/configuration/BroadcasterConfigurationEntryProperties.java
@@ -50,8 +50,8 @@ public final class BroadcasterConfigurationEntryProperties
     }
 
     @Override
-    public Optional<Map<String, Object>> getAdditionalProperties() {
-        return Optional.ofNullable(additionalProperties);
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties == null ? Map.of() : this.additionalProperties;
     }
 
     @Override


### PR DESCRIPTION
- Tests for broadcaster descriptors
- BroadcasterConfigurationDescriptor's getAdditionalProperties will return a Map<String, Object> instead of an Optional<Map<String, Object>>