### PR TITLE
chore: Add GitHub Packages publishing support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,3 +142,39 @@ jobs:
         with:
           name: integration-jacoco-html
           path: integration-tests/build/reports/jacoco-html/
+
+  publish-packages:
+    runs-on: ubuntu-latest
+    needs: [ test-modules, integration-tests-on-main ]
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install pre-requisites
+        uses: ./.github/actions/setup
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore Gradle cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle
+
+      - name: Build and publish packages
+        run: ./gradlew publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'org.springframework.boot' version '3.3.1'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'io.freefair.lombok' version '8.12.1'
-    id 'com.gradle.plugin-publish' version '1.2.1'
+    id 'maven-publish'
 }
 
 description = 'Naryo base project'
@@ -27,8 +27,25 @@ allprojects {
 
     tasks.withType(Test).tap {
         configureEach {
-            reports.html.destination = file("${reporting.baseDir}/${name}")
+            reports.html.destination(file("${reporting.baseDir}/${name}"))
             useJUnitPlatform()
+        }
+    }
+
+    plugins.withType(PublishingPlugin).tap {
+        configureEach {
+            publishing {
+                repositories {
+                    maven {
+                        name = "GitHubPackages"
+                        url = uri("ghcr.io/lf-decentralized-trust-labs/naryo")
+                        credentials {
+                            username = System.getenv("GITHUB_ACTOR")
+                            password = System.getenv("GITHUB_TOKEN")
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'java-library'
     id 'io.freefair.lombok'
-    id 'com.gradle.plugin-publish'
     id 'java-test-fixtures'
+    id 'maven-publish'
 }
 
 ext {
@@ -61,4 +61,14 @@ tasks.named('test', Test) {
 
 tasks.named("spotlessJava").configure {
     dependsOn("spotlessGroovyGradle", "compileJava", "compileTestJava", "javadoc")
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId = 'core'
+
+            from components.java
+        }
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=io.naryo
-version=0.1.0
+version=0.1.0-beta

--- a/initializer/build.gradle
+++ b/initializer/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'java-library'
     id 'application'
+    id 'maven-publish'
 }
 
 ext {
@@ -29,4 +29,20 @@ application {
 
 tasks.named("spotlessJava").configure {
     dependsOn("spotlessGroovyGradle", "compileJava", "compileTestJava", "javadoc")
+}
+
+jar {
+    manifest {
+        attributes(
+                'Main-Class': 'io.naryo.cli.Initializer'
+                )
+    }
+}
+
+publishing {
+    publications {
+        cliJar(MavenPublication) {
+            artifact(jar)
+        }
+    }
 }

--- a/initializer/src/main/resources/modules.json
+++ b/initializer/src/main/resources/modules.json
@@ -4,7 +4,7 @@
       "id": "core",
       "groupId": "io.naryo",
       "artifactId": "core",
-      "version": "0.1.0",
+      "version": "0.1.0-beta",
       "description": "Naryo core support",
       "required": true
     },
@@ -12,7 +12,7 @@
       "id": "spring",
       "groupId": "io.naryo",
       "artifactId": "spring-core",
-      "version": "0.1.0",
+      "version": "0.1.0-beta",
       "description": "Naryo spring core support",
       "required": true
     },
@@ -20,7 +20,7 @@
       "id": "mongo",
       "groupId": "io.naryo",
       "artifactId": "persistence-spring-mongo",
-      "version": "0.1.0",
+      "version": "0.1.0-beta",
       "description": "Naryo mongo support",
       "required": false
     }

--- a/persistence-spring-mongo/build.gradle
+++ b/persistence-spring-mongo/build.gradle
@@ -2,46 +2,42 @@ plugins {
     id 'java-library'
     id 'org.springframework.boot'
     id 'io.spring.dependency-management'
-    id 'com.gradle.plugin-publish'
+    id 'maven-publish'
 }
 
 ext {
     mockitoVersion = '5.17.0'
-}
-
-group = 'io.naryo'
-version = '0.1.0'
-
-repositories {
-    mavenCentral()
+    instancioJunitVersion = '5.4.0'
 }
 
 dependencies {
     implementation project(':spring-core')
     implementation project(':core')
+    implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
-
-    implementation 'org.springframework:spring-context'
-    implementation 'org.springframework:spring-beans'
     implementation 'jakarta.validation:jakarta.validation-api'
 
     compileOnly 'org.projectlombok:lombok'
+
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation testFixtures(project(':core'))
-    testImplementation platform('org.junit:junit-bom:5.10.0')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
-    testImplementation "org.mockito:mockito-core:$mockitoVersion"
-    testImplementation "org.mockito:mockito-junit-jupiter:$mockitoVersion"
-    testImplementation 'org.instancio:instancio-junit:5.4.0'
-}
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation "org.instancio:instancio-junit:$instancioJunitVersion"
 
-test {
-    useJUnitPlatform()
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('bootJar') { enabled = false }
 
 tasks.named("spotlessJava").configure {
     dependsOn("spotlessGroovyGradle", "compileJava", "compileTestJava", "javadoc")
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
 }

--- a/spring-core/build.gradle
+++ b/spring-core/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-library'
     id 'io.freefair.lombok'
     id 'org.springframework.boot'
-    id 'com.gradle.plugin-publish'
+    id 'maven-publish'
     id 'io.spring.dependency-management'
 }
 
@@ -26,7 +26,6 @@ dependencies {
     implementation "org.web3j:core:$web3jVersion"
     implementation 'org.hibernate.validator:hibernate-validator'
     implementation 'jakarta.validation:jakarta.validation-api'
-
 
     compileOnly 'org.projectlombok:lombok'
 
@@ -52,7 +51,7 @@ tasks.named('test', Test) {
                 "-XX:+EnableDynamicAgentLoading"
             ]
         } else {
-            logger.warn("⚠️  byte-buddy-agent JAR not found on testRuntimeClasspath; inline mock-maker may break on future JDKs.")
+            logger.warn("⚠️ byte-buddy-agent JAR not found on testRuntimeClasspath; inline mock-maker may break on future JDKs.")
         }
     }
 
@@ -65,4 +64,12 @@ tasks.named('bootJar') { enabled = false }
 
 tasks.named("spotlessJava").configure {
     dependsOn("spotlessGroovyGradle", "compileJava", "compileTestJava", "javadoc")
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
 }


### PR DESCRIPTION
- Add publish-packages job to GitHub workflow for automatic publishing on main branch
- Configure maven-publish plugin and GitHub Packages repository in build.gradle
- Update version to 0.1.0-beta for beta release
- Configure publishing settings across all modules
- Add GitHub Container Registry authentication

This enables automatic publishing of Naryo packages to GitHub Packages when changes are merged to main.