### PR TITLE
Chore: implement filter domain in jpa module

### DIFF
--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/FilterEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/FilterEntity.java
@@ -1,0 +1,50 @@
+package io.naryo.infrastructure.configuration.persistence.entity.filter;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import io.naryo.application.configuration.source.model.filter.FilterDescriptor;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "filters")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "filter_type")
+@NoArgsConstructor
+@AllArgsConstructor
+public abstract class FilterEntity implements FilterDescriptor {
+
+    private @Id UUID id;
+
+    private @Nullable String name;
+
+    private @Nullable UUID nodeId;
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public void setNodeId(UUID nodeId) {
+        this.nodeId = nodeId;
+    }
+
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+
+    @Override
+    public Optional<String> getName() {
+        return Optional.ofNullable(name);
+    }
+
+    @Override
+    public Optional<UUID> getNodeId() {
+        return nodeId == null ? Optional.empty() : Optional.of(nodeId);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/FilterEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/FilterEntity.java
@@ -12,16 +12,15 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "filters")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
-@DiscriminatorColumn(name = "filter_type")
 @NoArgsConstructor
 @AllArgsConstructor
 public abstract class FilterEntity implements FilterDescriptor {
 
-    private @Id UUID id;
+    private @Column(name = "id") @Id UUID id;
 
-    private @Nullable String name;
+    private @Column(name = "name") @Nullable String name;
 
-    private @Nullable UUID nodeId;
+    private @Column(name = "node_id") @Nullable UUID nodeId;
 
     @Override
     public void setName(String name) {

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/ContractEventFilterEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/ContractEventFilterEntity.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 
 import io.naryo.application.configuration.source.model.filter.event.contract.ContractEventFilterDescriptor;
 import io.naryo.domain.common.event.ContractEventStatus;
-import io.naryo.infrastructure.configuration.persistence.entity.filter.event.sync.FilterSync;
+import io.naryo.infrastructure.configuration.persistence.entity.filter.event.sync.FilterSyncEntity;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
@@ -15,13 +15,13 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@DiscriminatorValue("contract")
+@DiscriminatorValue("event_contract")
 @Setter
 @NoArgsConstructor
 public class ContractEventFilterEntity extends EventFilterEntity
         implements ContractEventFilterDescriptor {
 
-    private @Column(name = "contract_address") @Nullable String address;
+    private @Column(name = "address") @Nullable String address;
 
     public ContractEventFilterEntity(
             UUID id,
@@ -29,7 +29,7 @@ public class ContractEventFilterEntity extends EventFilterEntity
             UUID nodeId,
             EventSpecification specification,
             Set<ContractEventStatus> statuses,
-            FilterSync sync,
+            FilterSyncEntity sync,
             FilterVisibility visibility,
             String address) {
         super(id, name, nodeId, specification, statuses, sync, visibility);

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/ContractEventFilterEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/ContractEventFilterEntity.java
@@ -1,0 +1,43 @@
+package io.naryo.infrastructure.configuration.persistence.entity.filter.event;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import io.naryo.application.configuration.source.model.filter.event.contract.ContractEventFilterDescriptor;
+import io.naryo.domain.common.event.ContractEventStatus;
+import io.naryo.infrastructure.configuration.persistence.entity.filter.event.sync.FilterSync;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@DiscriminatorValue("contract")
+@Setter
+@NoArgsConstructor
+public class ContractEventFilterEntity extends EventFilterEntity
+        implements ContractEventFilterDescriptor {
+
+    private @Column(name = "contract_address") @Nullable String address;
+
+    public ContractEventFilterEntity(
+            UUID id,
+            String name,
+            UUID nodeId,
+            EventSpecification specification,
+            Set<ContractEventStatus> statuses,
+            FilterSync sync,
+            FilterVisibility visibility,
+            String address) {
+        super(id, name, nodeId, specification, statuses, sync, visibility);
+        this.address = address;
+    }
+
+    @Override
+    public Optional<String> getAddress() {
+        return Optional.ofNullable(address);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/EventFilterEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/EventFilterEntity.java
@@ -1,0 +1,96 @@
+package io.naryo.infrastructure.configuration.persistence.entity.filter.event;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import io.naryo.application.configuration.source.model.filter.event.EventFilterDescriptor;
+import io.naryo.application.configuration.source.model.filter.event.EventSpecificationDescriptor;
+import io.naryo.application.configuration.source.model.filter.event.FilterVisibilityDescriptor;
+import io.naryo.application.configuration.source.model.filter.event.sync.BlockFilterSyncDescriptor;
+import io.naryo.application.configuration.source.model.filter.event.sync.FilterSyncDescriptor;
+import io.naryo.domain.common.event.ContractEventStatus;
+import io.naryo.infrastructure.configuration.persistence.entity.filter.FilterEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.filter.event.sync.BlockFilterSyncEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.filter.event.sync.FilterSync;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import static io.naryo.application.common.util.OptionalUtil.valueOrNull;
+
+@Entity
+@DiscriminatorValue("event")
+@NoArgsConstructor
+public abstract class EventFilterEntity extends FilterEntity implements EventFilterDescriptor {
+
+    private @Embedded @Nullable EventSpecification specification;
+
+    private @ElementCollection(fetch = FetchType.EAGER) @Enumerated(EnumType.STRING) @Setter @Getter
+    Set<ContractEventStatus> statuses;
+
+    private @ManyToOne(cascade = CascadeType.ALL) @JoinColumn(name = "sync_id") @Nullable FilterSync
+            sync;
+
+    private @Embedded @Nullable FilterVisibility visibility;
+
+    public EventFilterEntity(
+            UUID id,
+            String name,
+            UUID nodeId,
+            EventSpecification specification,
+            Set<ContractEventStatus> statuses,
+            FilterSync sync,
+            FilterVisibility visibility) {
+        super(id, name, nodeId);
+        this.specification = specification;
+        this.statuses = statuses == null ? new HashSet<>() : statuses;
+        this.sync = sync;
+        this.visibility = visibility;
+    }
+
+    @Override
+    public void setSpecification(EventSpecificationDescriptor specification) {
+        this.specification =
+                new EventSpecification(
+                        valueOrNull(specification.getSignature()),
+                        valueOrNull(specification.getCorrelationId()));
+    }
+
+    @Override
+    public void setSync(FilterSyncDescriptor sync) {
+        if (sync instanceof BlockFilterSyncDescriptor blockFilterSyncDescriptor) {
+            this.sync =
+                    new BlockFilterSyncEntity(
+                            valueOrNull(blockFilterSyncDescriptor.getInitialBlock()));
+        } else {
+            throw new IllegalArgumentException("Unknown sync strategy: " + sync.getStrategy());
+        }
+    }
+
+    @Override
+    public void setVisibility(FilterVisibilityDescriptor visibility) {
+        this.visibility =
+                new FilterVisibility(
+                        valueOrNull(visibility.getVisible()),
+                        valueOrNull(visibility.getPrivacyGroupId()));
+    }
+
+    @Override
+    public Optional<EventSpecification> getSpecification() {
+        return Optional.ofNullable(specification);
+    }
+
+    @Override
+    public Optional<FilterSync> getSync() {
+        return Optional.ofNullable(sync);
+    }
+
+    @Override
+    public Optional<FilterVisibility> getVisibility() {
+        return Optional.ofNullable(visibility);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/EventFilterEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/EventFilterEntity.java
@@ -13,7 +13,7 @@ import io.naryo.application.configuration.source.model.filter.event.sync.FilterS
 import io.naryo.domain.common.event.ContractEventStatus;
 import io.naryo.infrastructure.configuration.persistence.entity.filter.FilterEntity;
 import io.naryo.infrastructure.configuration.persistence.entity.filter.event.sync.BlockFilterSyncEntity;
-import io.naryo.infrastructure.configuration.persistence.entity.filter.event.sync.FilterSync;
+import io.naryo.infrastructure.configuration.persistence.entity.filter.event.sync.FilterSyncEntity;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -23,7 +23,6 @@ import lombok.Setter;
 import static io.naryo.application.common.util.OptionalUtil.valueOrNull;
 
 @Entity
-@DiscriminatorValue("event")
 @NoArgsConstructor
 public abstract class EventFilterEntity extends FilterEntity implements EventFilterDescriptor {
 
@@ -32,8 +31,8 @@ public abstract class EventFilterEntity extends FilterEntity implements EventFil
     private @ElementCollection(fetch = FetchType.EAGER) @Enumerated(EnumType.STRING) @Setter @Getter
     Set<ContractEventStatus> statuses;
 
-    private @ManyToOne(cascade = CascadeType.ALL) @JoinColumn(name = "sync_id") @Nullable FilterSync
-            sync;
+    private @ManyToOne(cascade = CascadeType.ALL) @JoinColumn(name = "sync_id") @Nullable
+    FilterSyncEntity sync;
 
     private @Embedded @Nullable FilterVisibility visibility;
 
@@ -43,7 +42,7 @@ public abstract class EventFilterEntity extends FilterEntity implements EventFil
             UUID nodeId,
             EventSpecification specification,
             Set<ContractEventStatus> statuses,
-            FilterSync sync,
+            FilterSyncEntity sync,
             FilterVisibility visibility) {
         super(id, name, nodeId);
         this.specification = specification;
@@ -85,7 +84,7 @@ public abstract class EventFilterEntity extends FilterEntity implements EventFil
     }
 
     @Override
-    public Optional<FilterSync> getSync() {
+    public Optional<FilterSyncEntity> getSync() {
         return Optional.ofNullable(sync);
     }
 

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/EventSpecification.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/EventSpecification.java
@@ -1,0 +1,36 @@
+package io.naryo.infrastructure.configuration.persistence.entity.filter.event;
+
+import java.util.Optional;
+
+import io.naryo.application.configuration.source.model.filter.event.EventSpecificationDescriptor;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Embeddable
+@Setter
+@NoArgsConstructor
+public class EventSpecification implements EventSpecificationDescriptor {
+
+    @Column(name = "specification_signature")
+    private @Nullable String signature;
+
+    @Column(name = "specification_correlation_id")
+    private @Nullable Integer correlationId;
+
+    public EventSpecification(String signature, Integer correlationId) {
+        this.signature = signature;
+        this.correlationId = correlationId;
+    }
+
+    @Override
+    public Optional<String> getSignature() {
+        return Optional.ofNullable(signature);
+    }
+
+    @Override
+    public Optional<Integer> getCorrelationId() {
+        return Optional.ofNullable(correlationId);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/EventSpecification.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/EventSpecification.java
@@ -13,10 +13,10 @@ import lombok.Setter;
 @NoArgsConstructor
 public class EventSpecification implements EventSpecificationDescriptor {
 
-    @Column(name = "specification_signature")
+    @Column(name = "signature")
     private @Nullable String signature;
 
-    @Column(name = "specification_correlation_id")
+    @Column(name = "correlation_id")
     private @Nullable Integer correlationId;
 
     public EventSpecification(String signature, Integer correlationId) {

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/FilterVisibility.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/FilterVisibility.java
@@ -1,0 +1,34 @@
+package io.naryo.infrastructure.configuration.persistence.entity.filter.event;
+
+import java.util.Optional;
+
+import io.naryo.application.configuration.source.model.filter.event.FilterVisibilityDescriptor;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Embeddable
+@Setter
+@NoArgsConstructor
+public class FilterVisibility implements FilterVisibilityDescriptor {
+
+    private @Column(name = "visibility_visible") @Nullable Boolean visible;
+
+    private @Column(name = "visibility_privacy_group_id") @Nullable String privacyGroupId;
+
+    public FilterVisibility(Boolean visible, String privacyGroupId) {
+        this.visible = visible;
+        this.privacyGroupId = privacyGroupId;
+    }
+
+    @Override
+    public Optional<Boolean> getVisible() {
+        return Optional.ofNullable(visible);
+    }
+
+    @Override
+    public Optional<String> getPrivacyGroupId() {
+        return Optional.ofNullable(privacyGroupId);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/FilterVisibility.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/FilterVisibility.java
@@ -13,9 +13,9 @@ import lombok.Setter;
 @NoArgsConstructor
 public class FilterVisibility implements FilterVisibilityDescriptor {
 
-    private @Column(name = "visibility_visible") @Nullable Boolean visible;
+    private @Column(name = "visible") @Nullable Boolean visible;
 
-    private @Column(name = "visibility_privacy_group_id") @Nullable String privacyGroupId;
+    private @Column(name = "privacy_group_id") @Nullable String privacyGroupId;
 
     public FilterVisibility(Boolean visible, String privacyGroupId) {
         this.visible = visible;

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/GlobalEventFilterEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/GlobalEventFilterEntity.java
@@ -1,0 +1,29 @@
+package io.naryo.infrastructure.configuration.persistence.entity.filter.event;
+
+import java.util.Set;
+import java.util.UUID;
+
+import io.naryo.application.configuration.source.model.filter.event.global.GlobalEventFilterDescriptor;
+import io.naryo.domain.common.event.ContractEventStatus;
+import io.naryo.infrastructure.configuration.persistence.entity.filter.event.sync.FilterSync;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("global")
+@NoArgsConstructor
+public class GlobalEventFilterEntity extends EventFilterEntity
+        implements GlobalEventFilterDescriptor {
+
+    public GlobalEventFilterEntity(
+            UUID id,
+            String name,
+            UUID nodeId,
+            EventSpecification specification,
+            Set<ContractEventStatus> statuses,
+            FilterSync sync,
+            FilterVisibility visibility) {
+        super(id, name, nodeId, specification, statuses, sync, visibility);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/GlobalEventFilterEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/GlobalEventFilterEntity.java
@@ -5,13 +5,13 @@ import java.util.UUID;
 
 import io.naryo.application.configuration.source.model.filter.event.global.GlobalEventFilterDescriptor;
 import io.naryo.domain.common.event.ContractEventStatus;
-import io.naryo.infrastructure.configuration.persistence.entity.filter.event.sync.FilterSync;
+import io.naryo.infrastructure.configuration.persistence.entity.filter.event.sync.FilterSyncEntity;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import lombok.NoArgsConstructor;
 
 @Entity
-@DiscriminatorValue("global")
+@DiscriminatorValue("event_global")
 @NoArgsConstructor
 public class GlobalEventFilterEntity extends EventFilterEntity
         implements GlobalEventFilterDescriptor {
@@ -22,7 +22,7 @@ public class GlobalEventFilterEntity extends EventFilterEntity
             UUID nodeId,
             EventSpecification specification,
             Set<ContractEventStatus> statuses,
-            FilterSync sync,
+            FilterSyncEntity sync,
             FilterVisibility visibility) {
         super(id, name, nodeId, specification, statuses, sync, visibility);
     }

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/sync/BlockFilterSyncEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/sync/BlockFilterSyncEntity.java
@@ -17,8 +17,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class BlockFilterSyncEntity extends FilterSyncEntity implements BlockFilterSyncDescriptor {
 
-    @Column(name = "initial_block")
-    private @Nullable BigInteger initialBlock;
+    private @Column(name = "initial_block") @Nullable BigInteger initialBlock;
 
     public BlockFilterSyncEntity(BigInteger initialBlock) {
         super();

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/sync/BlockFilterSyncEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/sync/BlockFilterSyncEntity.java
@@ -1,0 +1,32 @@
+package io.naryo.infrastructure.configuration.persistence.entity.filter.event.sync;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+import io.naryo.application.configuration.source.model.filter.event.sync.BlockFilterSyncDescriptor;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@DiscriminatorValue("block")
+@Setter
+@NoArgsConstructor
+public class BlockFilterSyncEntity extends FilterSync implements BlockFilterSyncDescriptor {
+
+    @Column(name = "sync_initial_block")
+    private @Nullable BigInteger initialBlock;
+
+    public BlockFilterSyncEntity(BigInteger initialBlock) {
+        super();
+        this.initialBlock = initialBlock;
+    }
+
+    @Override
+    public Optional<BigInteger> getInitialBlock() {
+        return Optional.ofNullable(initialBlock);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/sync/BlockFilterSyncEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/sync/BlockFilterSyncEntity.java
@@ -15,9 +15,9 @@ import lombok.Setter;
 @DiscriminatorValue("block")
 @Setter
 @NoArgsConstructor
-public class BlockFilterSyncEntity extends FilterSync implements BlockFilterSyncDescriptor {
+public class BlockFilterSyncEntity extends FilterSyncEntity implements BlockFilterSyncDescriptor {
 
-    @Column(name = "sync_initial_block")
+    @Column(name = "initial_block")
     private @Nullable BigInteger initialBlock;
 
     public BlockFilterSyncEntity(BigInteger initialBlock) {

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/sync/FilterSync.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/sync/FilterSync.java
@@ -1,0 +1,19 @@
+package io.naryo.infrastructure.configuration.persistence.entity.filter.event.sync;
+
+import java.util.UUID;
+
+import io.naryo.application.configuration.source.model.filter.event.sync.FilterSyncDescriptor;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "sync_type")
+@NoArgsConstructor
+@Getter
+public abstract class FilterSync implements FilterSyncDescriptor {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/sync/FilterSyncEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/sync/FilterSyncEntity.java
@@ -9,11 +9,9 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
-@DiscriminatorColumn(name = "sync_type")
 @NoArgsConstructor
 @Getter
 public abstract class FilterSyncEntity implements FilterSyncDescriptor {
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+
+    private @Id @GeneratedValue(strategy = GenerationType.UUID) @Column(name = "id") UUID id;
 }

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/sync/FilterSyncEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/event/sync/FilterSyncEntity.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @DiscriminatorColumn(name = "sync_type")
 @NoArgsConstructor
 @Getter
-public abstract class FilterSync implements FilterSyncDescriptor {
+public abstract class FilterSyncEntity implements FilterSyncDescriptor {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/transaction/TransactionFilterEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/transaction/TransactionFilterEntity.java
@@ -1,0 +1,55 @@
+package io.naryo.infrastructure.configuration.persistence.entity.filter.transaction;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import io.naryo.application.configuration.source.model.filter.transaction.TransactionFilterDescriptor;
+import io.naryo.domain.common.TransactionStatus;
+import io.naryo.domain.filter.transaction.IdentifierType;
+import io.naryo.infrastructure.configuration.persistence.entity.filter.FilterEntity;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@DiscriminatorValue("transaction")
+@NoArgsConstructor
+public class TransactionFilterEntity extends FilterEntity implements TransactionFilterDescriptor {
+
+    private @Nullable @Setter IdentifierType identifierType;
+    private @Nullable @Setter String value;
+    private @ElementCollection(fetch = FetchType.EAGER) @Enumerated(EnumType.STRING) @Setter Set<
+                    TransactionStatus>
+            statuses;
+
+    public TransactionFilterEntity(
+            UUID id,
+            String name,
+            UUID nodeId,
+            IdentifierType identifierType,
+            String value,
+            Set<TransactionStatus> statuses) {
+        super(id, name, nodeId);
+        this.identifierType = identifierType;
+        this.value = value;
+        this.statuses = statuses == null ? new HashSet<>() : statuses;
+    }
+
+    @Override
+    public Optional<IdentifierType> getIdentifierType() {
+        return Optional.ofNullable(identifierType);
+    }
+
+    @Override
+    public Optional<String> getValue() {
+        return Optional.ofNullable(value);
+    }
+
+    @Override
+    public Set<TransactionStatus> getStatuses() {
+        return statuses == null ? Set.of() : statuses;
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/transaction/TransactionFilterEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/transaction/TransactionFilterEntity.java
@@ -19,11 +19,10 @@ import lombok.Setter;
 @NoArgsConstructor
 public class TransactionFilterEntity extends FilterEntity implements TransactionFilterDescriptor {
 
-    private @Nullable @Setter IdentifierType identifierType;
-    private @Nullable @Setter String value;
-    private @ElementCollection(fetch = FetchType.EAGER) @Enumerated(EnumType.STRING) @Setter Set<
-                    TransactionStatus>
-            statuses;
+    private @Column(name = "identifier_type") @Nullable @Setter IdentifierType identifierType;
+    private @Column(name = "value") @Nullable @Setter String value;
+    private @Column(name = "statuses") @ElementCollection(fetch = FetchType.EAGER) @Enumerated(
+            EnumType.STRING) @Setter Set<TransactionStatus> statuses;
 
     public TransactionFilterEntity(
             UUID id,

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/repository/filter/FilterRepository.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/repository/filter/FilterRepository.java
@@ -1,0 +1,8 @@
+package io.naryo.infrastructure.configuration.persistence.repository.filter;
+
+import java.util.UUID;
+
+import io.naryo.infrastructure.configuration.persistence.entity.filter.FilterEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FilterRepository extends JpaRepository<FilterEntity, UUID> {}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/provider/broadcaster/JpaBroadcasterConfigurationSourceProvider.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/provider/broadcaster/JpaBroadcasterConfigurationSourceProvider.java
@@ -1,4 +1,4 @@
-package io.naryo.infrastructure.configuration.provider;
+package io.naryo.infrastructure.configuration.provider.broadcaster;
 
 import java.util.Collection;
 import java.util.HashSet;

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/provider/broadcaster/JpaBroadcasterSourceProvider.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/provider/broadcaster/JpaBroadcasterSourceProvider.java
@@ -1,4 +1,4 @@
-package io.naryo.infrastructure.configuration.provider;
+package io.naryo.infrastructure.configuration.provider.broadcaster;
 
 import java.util.Collection;
 import java.util.HashSet;

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/provider/filter/JpaFilterSourceProvider.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/provider/filter/JpaFilterSourceProvider.java
@@ -1,0 +1,32 @@
+package io.naryo.infrastructure.configuration.provider.filter;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+import io.naryo.application.configuration.source.model.filter.FilterDescriptor;
+import io.naryo.application.filter.configuration.provider.FilterSourceProvider;
+import io.naryo.infrastructure.configuration.persistence.entity.filter.FilterEntity;
+import io.naryo.infrastructure.configuration.persistence.repository.filter.FilterRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JpaFilterSourceProvider implements FilterSourceProvider {
+
+    private final FilterRepository repository;
+
+    public JpaFilterSourceProvider(FilterRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Collection<FilterDescriptor> load() {
+        List<FilterEntity> filters = this.repository.findAll();
+        return new HashSet<>(filters);
+    }
+
+    @Override
+    public int priority() {
+        return 0;
+    }
+}


### PR DESCRIPTION
This pull request implements filter domain in the dedicated persistence-spring-jpa module. It includes the creation of a hierarchy of filter-related entities, repositories, and providers to support various types of filters such as event filters, transaction filters, and their associated configurations.

### Entity Hierarchy and Filter Management

- Introduced FilterEntity as a base class, with EventFilterEntity and TransactionFilterEntity as specializations.

- Added concrete variants: ContractEventFilterEntity, GlobalEventFilterEntity

### Embedded and Supporting Entities

- Added embeddables: EventSpecification, FilterVisibility.

- Defined sync strategy with FilterSync and BlockFilterSyncEntity.

### Repository and Provider Layer

- Created FilterRepository for JPA operations.

- Implemented JpaFilterSourceProvider to expose filters as descriptors.
