### PR TITLE
chore: homegenise field annotations in broadcaster jpa implementation

### DIFF
--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/BroadcasterEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/BroadcasterEntity.java
@@ -24,7 +24,7 @@ import static io.naryo.application.common.util.OptionalUtil.valueOrNull;
 @NoArgsConstructor
 public final class BroadcasterEntity implements BroadcasterDescriptor {
 
-    private @Id UUID id;
+    private @Column(name = "id") @Id UUID id;
 
     private @Column(name = "configuration_id") UUID configurationId;
 

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/configuration/BroadcasterCacheEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/configuration/BroadcasterCacheEntity.java
@@ -3,6 +3,7 @@ package io.naryo.infrastructure.configuration.persistence.entity.broadcaster.con
 import java.time.Duration;
 
 import io.naryo.application.configuration.source.model.broadcaster.configuration.BroadcasterCacheConfigurationDescriptor;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -13,7 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class BroadcasterCacheEntity implements BroadcasterCacheConfigurationDescriptor {
 
-    private @NotNull Duration expirationTime;
+    private @Column(name = "expiration_time") @NotNull Duration expirationTime;
 
     public BroadcasterCacheEntity(Duration expirationTime) {
         this.expirationTime = expirationTime;

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/configuration/BroadcasterConfigurationEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/configuration/BroadcasterConfigurationEntity.java
@@ -27,9 +27,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public final class BroadcasterConfigurationEntity implements BroadcasterConfigurationDescriptor {
 
-    private @Id UUID id;
+    private @Column(name = "id") @Id UUID id;
 
-    private @NotNull @NotBlank String type;
+    private @Column(name = "type") @NotNull @NotBlank String type;
 
     private @Embedded @Valid BroadcasterCacheEntity cache;
 

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/configuration/schema/ConfigurationSchemaEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/configuration/schema/ConfigurationSchemaEntity.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class ConfigurationSchemaEntity {
 
-    private @Column(name = "schema_type") String type;
+    private @Column(name = "type") String type;
 
     private @ElementCollection(fetch = FetchType.EAGER) @CollectionTable(
             name = "broadcasters_configuration_fields",

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/configuration/schema/FieldDefinitionEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/configuration/schema/FieldDefinitionEntity.java
@@ -12,11 +12,11 @@ import lombok.NoArgsConstructor;
 @Getter
 public class FieldDefinitionEntity {
 
-    private String name;
+    private @Column(name = "name") String name;
 
-    private String typeName;
+    private @Column(name = "type_name") String typeName;
 
-    private boolean required;
+    private @Column(name = "required") boolean required;
 
     @Column(name = "default_value", columnDefinition = "TEXT")
     @Convert(converter = JsonObjectConverter.class)

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/target/BroadcasterTargetEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/target/BroadcasterTargetEntity.java
@@ -17,9 +17,9 @@ import lombok.NoArgsConstructor;
 @Getter
 public abstract class BroadcasterTargetEntity implements BroadcasterTargetDescriptor {
 
-    private @Id @GeneratedValue(strategy = GenerationType.IDENTITY) Long id;
+    private @Id @Column(name = "id") @GeneratedValue(strategy = GenerationType.IDENTITY) Long id;
 
-    private @Nullable @NotBlank String destination;
+    private @Column(name = "destination") @Nullable @NotBlank String destination;
 
     public BroadcasterTargetEntity(String destination) {
         this.destination = destination;


### PR DESCRIPTION
This pull request introduces changes to improve the consistency and clarity of JPA entity mappings by ensuring all fields are explicitly annotated with `@Column` where applicable. 