### PR TITLE
Chore: implement node domain in jpa module

### DIFF
--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/configuration/BroadcasterConfigurationEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/configuration/BroadcasterConfigurationEntity.java
@@ -29,7 +29,7 @@ public final class BroadcasterConfigurationEntity implements BroadcasterConfigur
 
     private @Column(name = "id") @Id UUID id;
 
-    private @Column(name = "type") @NotNull @NotBlank String type;
+    private @Column(name = "broadcaster_type") @NotNull @NotBlank String type;
 
     private @Embedded @Valid BroadcasterCacheEntity cache;
 

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/configuration/schema/ConfigurationSchemaEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/configuration/schema/ConfigurationSchemaEntity.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class ConfigurationSchemaEntity {
 
-    private @Column(name = "type") String type;
+    private @Column(name = "schema_type") String type;
 
     private @ElementCollection(fetch = FetchType.EAGER) @CollectionTable(
             name = "broadcasters_configuration_fields",

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/common/ConnectionEndpointEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/common/ConnectionEndpointEntity.java
@@ -1,0 +1,26 @@
+package io.naryo.infrastructure.configuration.persistence.entity.common;
+
+import java.util.Optional;
+
+import io.naryo.application.configuration.source.model.node.connection.endpoint.ConnectionEndpointDescriptor;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Embeddable
+@NoArgsConstructor
+public class ConnectionEndpointEntity implements ConnectionEndpointDescriptor {
+
+    private @Setter @Nullable @Column(name = "url") String url;
+
+    public ConnectionEndpointEntity(String url) {
+        this.url = url;
+    }
+
+    @Override
+    public Optional<String> getUrl() {
+        return Optional.ofNullable(url);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/NodeEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/NodeEntity.java
@@ -1,0 +1,162 @@
+package io.naryo.infrastructure.configuration.persistence.entity.node;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import io.naryo.application.configuration.source.model.node.NodeDescriptor;
+import io.naryo.application.configuration.source.model.node.connection.HttpNodeConnectionDescriptor;
+import io.naryo.application.configuration.source.model.node.connection.NodeConnectionDescriptor;
+import io.naryo.application.configuration.source.model.node.connection.WsNodeConnectionDescriptor;
+import io.naryo.application.configuration.source.model.node.interaction.EthereumRpcBlockInteractionDescriptor;
+import io.naryo.application.configuration.source.model.node.interaction.HederaMirrorNodeBlockInteractionDescriptor;
+import io.naryo.application.configuration.source.model.node.interaction.InteractionDescriptor;
+import io.naryo.application.configuration.source.model.node.subscription.PollBlockSubscriptionDescriptor;
+import io.naryo.application.configuration.source.model.node.subscription.PubsubBlockSubscriptionDescriptor;
+import io.naryo.application.configuration.source.model.node.subscription.SubscriptionDescriptor;
+import io.naryo.infrastructure.configuration.persistence.entity.node.connection.ConnectionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.connection.http.HttpConnectionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.connection.ws.WsConnectionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.interaction.InteractionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.interaction.block.EthereumRpcBlockInteractionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.interaction.block.HederaMirrorNodeBlockInteractionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.subscription.SubscriptionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.subscription.block.PollBlockSubscriptionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.subscription.block.PubSubBlockSubscriptionEntity;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+import static io.naryo.application.common.util.OptionalUtil.valueOrNull;
+
+@Entity
+@Table(name = "nodes")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "node_type")
+@NoArgsConstructor
+public abstract class NodeEntity implements NodeDescriptor {
+
+    private @Id @Column(name = "id") UUID id;
+
+    private @Nullable @Column(name = "name") String name;
+
+    private @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true) @JoinColumn(
+            name = "subscription_id") @Nullable SubscriptionEntity subscription;
+
+    private @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true) @JoinColumn(
+            name = "interaction_id") @Nullable InteractionEntity interaction;
+
+    private @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true) @JoinColumn(
+            name = "connection_id") @Nullable ConnectionEntity connection;
+
+    protected NodeEntity(
+            UUID id,
+            @Nullable String name,
+            @Nullable SubscriptionEntity subscription,
+            @Nullable InteractionEntity interaction,
+            @Nullable ConnectionEntity connection) {
+        this.id = id;
+        this.name = name;
+        this.subscription = subscription;
+        this.interaction = interaction;
+        this.connection = connection;
+    }
+
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+
+    @Override
+    public Optional<String> getName() {
+        return Optional.ofNullable(this.name);
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public Optional<SubscriptionDescriptor> getSubscription() {
+        return Optional.ofNullable(this.subscription);
+    }
+
+    @Override
+    public void setSubscription(SubscriptionDescriptor subscription) {
+        switch (subscription) {
+            case PubsubBlockSubscriptionDescriptor pubsub ->
+                    this.subscription =
+                            new PubSubBlockSubscriptionEntity(
+                                    valueOrNull(pubsub.getInitialBlock()),
+                                    valueOrNull(pubsub.getConfirmationBlocks()),
+                                    valueOrNull(pubsub.getMissingTxRetryBlocks()),
+                                    valueOrNull(pubsub.getEventInvalidationBlockThreshold()),
+                                    valueOrNull(pubsub.getReplayBlockOffset()),
+                                    valueOrNull(pubsub.getSyncBlockLimit()));
+            case PollBlockSubscriptionDescriptor poll ->
+                    this.subscription =
+                            new PollBlockSubscriptionEntity(
+                                    valueOrNull(poll.getInitialBlock()),
+                                    valueOrNull(poll.getConfirmationBlocks()),
+                                    valueOrNull(poll.getMissingTxRetryBlocks()),
+                                    valueOrNull(poll.getEventInvalidationBlockThreshold()),
+                                    valueOrNull(poll.getReplayBlockOffset()),
+                                    valueOrNull(poll.getSyncBlockLimit()),
+                                    valueOrNull(poll.getInterval()));
+            default ->
+                    throw new IllegalArgumentException(
+                            "Unsupported subscription type: "
+                                    + subscription.getClass().getSimpleName());
+        }
+    }
+
+    @Override
+    public Optional<InteractionEntity> getInteraction() {
+        return Optional.ofNullable(this.interaction);
+    }
+
+    @Override
+    public void setInteraction(InteractionDescriptor interaction) {
+        switch (interaction) {
+            case EthereumRpcBlockInteractionDescriptor ethereum ->
+                    this.interaction = new EthereumRpcBlockInteractionEntity();
+            case HederaMirrorNodeBlockInteractionDescriptor hedera ->
+                    this.interaction =
+                            new HederaMirrorNodeBlockInteractionEntity(
+                                    valueOrNull(hedera.getLimitPerRequest()),
+                                    valueOrNull(hedera.getRetriesPerRequest()));
+            default ->
+                    throw new IllegalArgumentException(
+                            "Unsupported interaction type: "
+                                    + interaction.getClass().getSimpleName());
+        }
+    }
+
+    @Override
+    public Optional<ConnectionEntity> getConnection() {
+        return Optional.ofNullable(this.connection);
+    }
+
+    @Override
+    public void setConnection(NodeConnectionDescriptor connection) {
+        switch (connection) {
+            case HttpNodeConnectionDescriptor http ->
+                    this.connection =
+                            new HttpConnectionEntity(
+                                    valueOrNull(http.getRetry()),
+                                    valueOrNull(http.getEndpoint()),
+                                    valueOrNull(http.getMaxIdleConnections()),
+                                    valueOrNull(http.getKeepAliveDuration()),
+                                    valueOrNull(http.getConnectionTimeout()),
+                                    valueOrNull(http.getReadTimeout()));
+            case WsNodeConnectionDescriptor ws ->
+                    this.connection =
+                            new WsConnectionEntity(
+                                    valueOrNull(ws.getRetry()), valueOrNull(ws.getEndpoint()));
+            default ->
+                    throw new IllegalArgumentException(
+                            "Unsupported connection type: "
+                                    + connection.getClass().getSimpleName());
+        }
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/connection/ConnectionEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/connection/ConnectionEntity.java
@@ -1,0 +1,64 @@
+package io.naryo.infrastructure.configuration.persistence.entity.node.connection;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import io.naryo.application.configuration.source.model.node.connection.NodeConnectionDescriptor;
+import io.naryo.application.configuration.source.model.node.connection.endpoint.ConnectionEndpointDescriptor;
+import io.naryo.application.configuration.source.model.node.connection.retry.NodeConnectionRetryDescriptor;
+import io.naryo.infrastructure.configuration.persistence.entity.common.ConnectionEndpointEntity;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+import static io.naryo.application.common.util.OptionalUtil.valueOrNull;
+
+@Entity
+@Table(name = "connections")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "connection_type", discriminatorType = DiscriminatorType.STRING)
+@NoArgsConstructor
+public abstract class ConnectionEntity implements NodeConnectionDescriptor {
+
+    private @Id @GeneratedValue(strategy = GenerationType.UUID) @Column(
+            name = "id",
+            nullable = false,
+            updatable = false) UUID id;
+
+    private @Embedded @Nullable NodeConnectionRetryEntity retry;
+
+    private @Embedded @Nullable ConnectionEndpointEntity endpoint;
+
+    public ConnectionEntity(
+            @Nullable NodeConnectionRetryEntity retry,
+            @Nullable ConnectionEndpointEntity endpoint) {
+        this.retry = retry != null ? retry : new NodeConnectionRetryEntity();
+        this.endpoint = endpoint;
+    }
+
+    @Override
+    public Optional<NodeConnectionRetryEntity> getRetry() {
+        return Optional.ofNullable(this.retry);
+    }
+
+    @Override
+    public void setRetry(NodeConnectionRetryDescriptor retry) {
+        this.retry =
+                new NodeConnectionRetryEntity(
+                        valueOrNull(retry.getTimes()), valueOrNull(retry.getBackoff()));
+    }
+
+    @Override
+    public Optional<ConnectionEndpointEntity> getEndpoint() {
+        return Optional.ofNullable(this.endpoint);
+    }
+
+    @Override
+    public void setEndpoint(ConnectionEndpointDescriptor endpoint) {
+        this.endpoint = new ConnectionEndpointEntity(valueOrNull(endpoint.getUrl()));
+    }
+
+    public UUID getId() {
+        return this.id;
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/connection/NodeConnectionRetryEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/connection/NodeConnectionRetryEntity.java
@@ -1,0 +1,39 @@
+package io.naryo.infrastructure.configuration.persistence.entity.node.connection;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.naryo.application.configuration.source.model.node.connection.retry.NodeConnectionRetryDescriptor;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Setter;
+
+@Embeddable
+public class NodeConnectionRetryEntity implements NodeConnectionRetryDescriptor {
+
+    private static final int DEFAULT_RETRY_TIMES = 3;
+    private static final Duration DEFAULT_BACKOFF = Duration.ofSeconds(30);
+
+    private @Setter @Nullable @Column(name = "times") Integer times;
+    private @Setter @Nullable @Column(name = "backoff") Duration backoff;
+
+    public NodeConnectionRetryEntity(@Nullable Integer times, @Nullable Duration backoff) {
+        this.times = times != null ? times : DEFAULT_RETRY_TIMES;
+        this.backoff = backoff != null ? backoff : DEFAULT_BACKOFF;
+    }
+
+    public NodeConnectionRetryEntity() {
+        this(DEFAULT_RETRY_TIMES, DEFAULT_BACKOFF);
+    }
+
+    @Override
+    public Optional<Integer> getTimes() {
+        return Optional.ofNullable(this.times);
+    }
+
+    @Override
+    public Optional<Duration> getBackoff() {
+        return Optional.ofNullable(this.backoff);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/connection/http/HttpConnectionEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/connection/http/HttpConnectionEntity.java
@@ -1,0 +1,68 @@
+package io.naryo.infrastructure.configuration.persistence.entity.node.connection.http;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import io.naryo.application.configuration.source.model.node.connection.HttpNodeConnectionDescriptor;
+import io.naryo.infrastructure.configuration.persistence.entity.common.ConnectionEndpointEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.connection.ConnectionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.connection.NodeConnectionRetryEntity;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@DiscriminatorValue("http")
+@NoArgsConstructor
+public class HttpConnectionEntity extends ConnectionEntity implements HttpNodeConnectionDescriptor {
+
+    private static final int DEFAULT_MAX_IDLE_CONNECTIONS = 5;
+    private static final Duration DEFAULT_KEEP_ALIVE_DURATION = Duration.ofMinutes(5);
+    private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(30);
+
+    private @Setter @Nullable @Column(name = "max_idle_connections") Integer maxIdleConnections;
+    private @Setter @Nullable @Column(name = "keep_alive_duration") Duration keepAliveDuration;
+    private @Setter @Nullable @Column(name = "connection_timeout") Duration connectionTimeout;
+    private @Setter @Nullable @Column(name = "read_timeout") Duration readTimeout;
+
+    public HttpConnectionEntity(
+            NodeConnectionRetryEntity retry,
+            ConnectionEndpointEntity endpoint,
+            @Nullable Integer maxIdleConnections,
+            @Nullable Duration keepAliveDuration,
+            @Nullable Duration connectionTimeout,
+            @Nullable Duration readTimeout) {
+        super(retry, endpoint);
+        this.maxIdleConnections =
+                maxIdleConnections != null ? maxIdleConnections : DEFAULT_MAX_IDLE_CONNECTIONS;
+        this.keepAliveDuration =
+                keepAliveDuration != null ? keepAliveDuration : DEFAULT_KEEP_ALIVE_DURATION;
+        this.connectionTimeout =
+                connectionTimeout != null ? connectionTimeout : DEFAULT_CONNECTION_TIMEOUT;
+        this.readTimeout = readTimeout != null ? readTimeout : DEFAULT_READ_TIMEOUT;
+    }
+
+    @Override
+    public Optional<Integer> getMaxIdleConnections() {
+        return Optional.ofNullable(this.maxIdleConnections);
+    }
+
+    @Override
+    public Optional<Duration> getKeepAliveDuration() {
+        return Optional.ofNullable(this.keepAliveDuration);
+    }
+
+    @Override
+    public Optional<Duration> getConnectionTimeout() {
+        return Optional.ofNullable(this.connectionTimeout);
+    }
+
+    @Override
+    public Optional<Duration> getReadTimeout() {
+        return Optional.ofNullable(this.readTimeout);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/connection/ws/WsConnectionEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/connection/ws/WsConnectionEntity.java
@@ -1,0 +1,19 @@
+package io.naryo.infrastructure.configuration.persistence.entity.node.connection.ws;
+
+import io.naryo.application.configuration.source.model.node.connection.WsNodeConnectionDescriptor;
+import io.naryo.infrastructure.configuration.persistence.entity.common.ConnectionEndpointEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.connection.ConnectionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.connection.NodeConnectionRetryEntity;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("ws")
+@NoArgsConstructor
+public class WsConnectionEntity extends ConnectionEntity implements WsNodeConnectionDescriptor {
+
+    public WsConnectionEntity(NodeConnectionRetryEntity retry, ConnectionEndpointEntity endpoint) {
+        super(retry, endpoint);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/eth/EthereumNodeEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/eth/EthereumNodeEntity.java
@@ -1,0 +1,28 @@
+package io.naryo.infrastructure.configuration.persistence.entity.node.eth;
+
+import java.util.UUID;
+
+import io.naryo.application.configuration.source.model.node.EthereumNodeDescriptor;
+import io.naryo.infrastructure.configuration.persistence.entity.node.NodeEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.connection.ConnectionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.interaction.InteractionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.subscription.SubscriptionEntity;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("ethereum")
+@NoArgsConstructor
+public abstract class EthereumNodeEntity extends NodeEntity implements EthereumNodeDescriptor {
+
+    public EthereumNodeEntity(
+            UUID id,
+            @Nullable String name,
+            @Nullable SubscriptionEntity subscription,
+            @Nullable InteractionEntity interaction,
+            @Nullable ConnectionEntity connection) {
+        super(id, name, subscription, interaction, connection);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/eth/PrivateEthereumNodeEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/eth/PrivateEthereumNodeEntity.java
@@ -1,0 +1,50 @@
+package io.naryo.infrastructure.configuration.persistence.entity.node.eth;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import io.naryo.application.configuration.source.model.node.PrivateEthereumNodeDescriptor;
+import io.naryo.infrastructure.configuration.persistence.entity.node.connection.ConnectionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.interaction.InteractionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.subscription.SubscriptionEntity;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Setter
+@DiscriminatorValue("private")
+@NoArgsConstructor
+public class PrivateEthereumNodeEntity extends EthereumNodeEntity
+        implements PrivateEthereumNodeDescriptor {
+
+    private @Column(name = "groupd_id") @Nullable String groupId;
+
+    private @Column(name = "precompiled_address") @Nullable String precompiledAddress;
+
+    public PrivateEthereumNodeEntity(
+            UUID id,
+            String name,
+            SubscriptionEntity subscription,
+            InteractionEntity interaction,
+            ConnectionEntity connection,
+            String groupId,
+            String precompiledAddress) {
+        super(id, name, subscription, interaction, connection);
+        this.groupId = groupId;
+        this.precompiledAddress = precompiledAddress;
+    }
+
+    @Override
+    public Optional<String> getGroupId() {
+        return Optional.ofNullable(this.groupId);
+    }
+
+    @Override
+    public Optional<String> getPrecompiledAddress() {
+        return Optional.ofNullable(this.precompiledAddress);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/eth/PublicEthereumNodeEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/eth/PublicEthereumNodeEntity.java
@@ -1,0 +1,27 @@
+package io.naryo.infrastructure.configuration.persistence.entity.node.eth;
+
+import java.util.UUID;
+
+import io.naryo.application.configuration.source.model.node.PublicEthereumNodeDescriptor;
+import io.naryo.infrastructure.configuration.persistence.entity.node.connection.ConnectionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.interaction.InteractionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.subscription.SubscriptionEntity;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("public")
+@NoArgsConstructor
+public class PublicEthereumNodeEntity extends EthereumNodeEntity
+        implements PublicEthereumNodeDescriptor {
+
+    public PublicEthereumNodeEntity(
+            UUID id,
+            String name,
+            SubscriptionEntity subscription,
+            InteractionEntity interaction,
+            ConnectionEntity connection) {
+        super(id, name, subscription, interaction, connection);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/hedera/HederaNodeEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/hedera/HederaNodeEntity.java
@@ -1,0 +1,28 @@
+package io.naryo.infrastructure.configuration.persistence.entity.node.hedera;
+
+import java.util.UUID;
+
+import io.naryo.application.configuration.source.model.node.HederaNodeDescriptor;
+import io.naryo.infrastructure.configuration.persistence.entity.node.NodeEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.connection.ConnectionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.interaction.InteractionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.subscription.SubscriptionEntity;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("hedera")
+@NoArgsConstructor
+public class HederaNodeEntity extends NodeEntity implements HederaNodeDescriptor {
+
+    public HederaNodeEntity(
+            UUID id,
+            @Nullable String name,
+            @Nullable SubscriptionEntity subscription,
+            @Nullable InteractionEntity interaction,
+            @Nullable ConnectionEntity connection) {
+        super(id, name, subscription, interaction, connection);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/interaction/InteractionEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/interaction/InteractionEntity.java
@@ -1,0 +1,24 @@
+package io.naryo.infrastructure.configuration.persistence.entity.node.interaction;
+
+import java.util.UUID;
+
+import io.naryo.application.configuration.source.model.node.interaction.InteractionDescriptor;
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "interactions")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "interaction_type", discriminatorType = DiscriminatorType.STRING)
+@NoArgsConstructor
+public abstract class InteractionEntity implements InteractionDescriptor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    public java.util.UUID getId() {
+        return this.id;
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/interaction/block/BlockInteractionEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/interaction/block/BlockInteractionEntity.java
@@ -1,0 +1,17 @@
+package io.naryo.infrastructure.configuration.persistence.entity.node.interaction.block;
+
+import io.naryo.application.configuration.source.model.node.interaction.BlockInteractionDescriptor;
+import io.naryo.domain.node.interaction.InteractionStrategy;
+import io.naryo.infrastructure.configuration.persistence.entity.node.interaction.InteractionEntity;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+@Entity
+@DiscriminatorValue("block")
+public abstract class BlockInteractionEntity extends InteractionEntity
+        implements BlockInteractionDescriptor {
+    @Override
+    public InteractionStrategy getStrategy() {
+        return InteractionStrategy.BLOCK_BASED;
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/interaction/block/EthereumRpcBlockInteractionEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/interaction/block/EthereumRpcBlockInteractionEntity.java
@@ -1,0 +1,10 @@
+package io.naryo.infrastructure.configuration.persistence.entity.node.interaction.block;
+
+import io.naryo.application.configuration.source.model.node.interaction.EthereumRpcBlockInteractionDescriptor;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+@Entity
+@DiscriminatorValue("ethereum")
+public class EthereumRpcBlockInteractionEntity extends BlockInteractionEntity
+        implements EthereumRpcBlockInteractionDescriptor {}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/interaction/block/HederaMirrorNodeBlockInteractionEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/interaction/block/HederaMirrorNodeBlockInteractionEntity.java
@@ -1,0 +1,44 @@
+package io.naryo.infrastructure.configuration.persistence.entity.node.interaction.block;
+
+import java.util.Optional;
+
+import io.naryo.application.configuration.source.model.node.interaction.HederaMirrorNodeBlockInteractionDescriptor;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.Setter;
+
+@Entity
+@DiscriminatorValue("hedera")
+public class HederaMirrorNodeBlockInteractionEntity extends BlockInteractionEntity
+        implements HederaMirrorNodeBlockInteractionDescriptor {
+
+    private static final Integer DEFAULT_LIMIT_PER_REQUEST = 10;
+    private static final Integer DEFAULT_RETRIES_PER_REQUEST = 3;
+
+    private @Setter @Nullable @Column(name = "limit_per_request") Integer limitPerRequest;
+    private @Setter @Nullable @Column(name = "retries_per_request") Integer retriesPerRequest;
+
+    public HederaMirrorNodeBlockInteractionEntity(
+            @Nullable Integer limitPerRequest, @Nullable Integer retriesPerRequest) {
+        this.limitPerRequest =
+                limitPerRequest != null ? limitPerRequest : DEFAULT_LIMIT_PER_REQUEST;
+        this.retriesPerRequest =
+                retriesPerRequest != null ? retriesPerRequest : DEFAULT_RETRIES_PER_REQUEST;
+    }
+
+    public HederaMirrorNodeBlockInteractionEntity() {
+        this(DEFAULT_LIMIT_PER_REQUEST, DEFAULT_RETRIES_PER_REQUEST);
+    }
+
+    @Override
+    public Optional<Integer> getLimitPerRequest() {
+        return Optional.ofNullable(this.limitPerRequest);
+    }
+
+    @Override
+    public Optional<Integer> getRetriesPerRequest() {
+        return Optional.ofNullable(this.retriesPerRequest);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/subscription/SubscriptionEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/subscription/SubscriptionEntity.java
@@ -1,0 +1,24 @@
+package io.naryo.infrastructure.configuration.persistence.entity.node.subscription;
+
+import java.util.UUID;
+
+import io.naryo.application.configuration.source.model.node.subscription.SubscriptionDescriptor;
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "subscriptions")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "subscription_type", discriminatorType = DiscriminatorType.STRING)
+@NoArgsConstructor
+public abstract class SubscriptionEntity implements SubscriptionDescriptor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    public java.util.UUID getId() {
+        return this.id;
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/subscription/block/BlockSubscriptionEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/subscription/block/BlockSubscriptionEntity.java
@@ -1,0 +1,99 @@
+package io.naryo.infrastructure.configuration.persistence.entity.node.subscription.block;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+import io.naryo.application.configuration.source.model.node.subscription.BlockSubscriptionDescriptor;
+import io.naryo.infrastructure.configuration.persistence.entity.node.subscription.SubscriptionEntity;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@DiscriminatorValue("block")
+@Setter
+@NoArgsConstructor
+public abstract class BlockSubscriptionEntity extends SubscriptionEntity
+        implements BlockSubscriptionDescriptor {
+
+    private static final BigInteger DEFAULT_INITIAL_BLOCK = BigInteger.valueOf(-1);
+    private static final BigInteger DEFAULT_CONFIRMATION_BLOCKS = BigInteger.valueOf(12);
+    private static final BigInteger DEFAULT_MISSING_TX_RETRY_BLOCKS = BigInteger.valueOf(200);
+    private static final BigInteger DEFAULT_EVENT_INVALIDATION_BLOCK_THRESHOLD = BigInteger.TWO;
+    private static final BigInteger DEFAULT_REPLAY_BLOCK_OFFSET = BigInteger.valueOf(12);
+    private static final BigInteger DEFAULT_SYNC_BLOCK_LIMIT = BigInteger.valueOf(20000);
+
+    @Column(name = "initial_block")
+    private @Nullable BigInteger initialBlock;
+
+    @Column(name = "confirmation_blocks")
+    private @Nullable BigInteger confirmationBlocks;
+
+    @Column(name = "missing_tx_retry_blocks")
+    private @Nullable BigInteger missingTxRetryBlocks;
+
+    @Column(name = "event_invalidation_block_threshold")
+    private @Nullable BigInteger eventInvalidationBlockThreshold;
+
+    @Column(name = "replay_block_offset")
+    private @Nullable BigInteger replayBlockOffset;
+
+    @Column(name = "sync_block_limit")
+    private @Nullable BigInteger syncBlockLimit;
+
+    public BlockSubscriptionEntity(
+            BigInteger initialBlock,
+            BigInteger confirmationBlocks,
+            BigInteger missingTxRetryBlocks,
+            BigInteger eventInvalidationBlockThreshold,
+            BigInteger replayBlockOffset,
+            BigInteger syncBlockLimit) {
+        this.initialBlock = initialBlock != null ? initialBlock : DEFAULT_INITIAL_BLOCK;
+        this.confirmationBlocks =
+                confirmationBlocks != null ? confirmationBlocks : DEFAULT_CONFIRMATION_BLOCKS;
+        this.missingTxRetryBlocks =
+                missingTxRetryBlocks != null
+                        ? missingTxRetryBlocks
+                        : DEFAULT_MISSING_TX_RETRY_BLOCKS;
+        this.eventInvalidationBlockThreshold =
+                eventInvalidationBlockThreshold != null
+                        ? eventInvalidationBlockThreshold
+                        : DEFAULT_EVENT_INVALIDATION_BLOCK_THRESHOLD;
+        this.replayBlockOffset =
+                replayBlockOffset != null ? replayBlockOffset : DEFAULT_REPLAY_BLOCK_OFFSET;
+        this.syncBlockLimit = syncBlockLimit != null ? syncBlockLimit : DEFAULT_SYNC_BLOCK_LIMIT;
+    }
+
+    @Override
+    public Optional<BigInteger> getInitialBlock() {
+        return Optional.ofNullable(this.initialBlock);
+    }
+
+    @Override
+    public Optional<BigInteger> getConfirmationBlocks() {
+        return Optional.ofNullable(this.confirmationBlocks);
+    }
+
+    @Override
+    public Optional<BigInteger> getMissingTxRetryBlocks() {
+        return Optional.ofNullable(this.missingTxRetryBlocks);
+    }
+
+    @Override
+    public Optional<BigInteger> getEventInvalidationBlockThreshold() {
+        return Optional.ofNullable(this.eventInvalidationBlockThreshold);
+    }
+
+    @Override
+    public Optional<BigInteger> getReplayBlockOffset() {
+        return Optional.ofNullable(this.replayBlockOffset);
+    }
+
+    @Override
+    public Optional<BigInteger> getSyncBlockLimit() {
+        return Optional.ofNullable(this.syncBlockLimit);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/subscription/block/PollBlockSubscriptionEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/subscription/block/PollBlockSubscriptionEntity.java
@@ -1,0 +1,47 @@
+package io.naryo.infrastructure.configuration.persistence.entity.node.subscription.block;
+
+import java.math.BigInteger;
+import java.time.Duration;
+import java.util.Optional;
+
+import io.naryo.application.configuration.source.model.node.subscription.PollBlockSubscriptionDescriptor;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.validation.constraints.NotNull;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@DiscriminatorValue("poll")
+@NoArgsConstructor
+public class PollBlockSubscriptionEntity extends BlockSubscriptionEntity
+        implements PollBlockSubscriptionDescriptor {
+
+    private static final Duration DEFAULT_INTERVAL = Duration.ofSeconds(5);
+
+    private @Column(name = "interval") @Setter @NotNull Duration interval;
+
+    public PollBlockSubscriptionEntity(
+            BigInteger initialBlock,
+            BigInteger confirmationBlocks,
+            BigInteger missingTxRetryBlocks,
+            BigInteger eventInvalidationBlockThreshold,
+            BigInteger replayBlockOffset,
+            BigInteger syncBlockLimit,
+            Duration interval) {
+        super(
+                initialBlock,
+                confirmationBlocks,
+                missingTxRetryBlocks,
+                eventInvalidationBlockThreshold,
+                replayBlockOffset,
+                syncBlockLimit);
+        this.interval = interval != null ? interval : DEFAULT_INTERVAL;
+    }
+
+    @Override
+    public Optional<Duration> getInterval() {
+        return Optional.ofNullable(this.interval);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/subscription/block/PubSubBlockSubscriptionEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/subscription/block/PubSubBlockSubscriptionEntity.java
@@ -1,0 +1,30 @@
+package io.naryo.infrastructure.configuration.persistence.entity.node.subscription.block;
+
+import java.math.BigInteger;
+
+import io.naryo.application.configuration.source.model.node.subscription.PubsubBlockSubscriptionDescriptor;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("pub-sub")
+@NoArgsConstructor
+public class PubSubBlockSubscriptionEntity extends BlockSubscriptionEntity
+        implements PubsubBlockSubscriptionDescriptor {
+    public PubSubBlockSubscriptionEntity(
+            BigInteger initialBlock,
+            BigInteger confirmationBlocks,
+            BigInteger missingTxRetryBlocks,
+            BigInteger eventInvalidationBlockThreshold,
+            BigInteger replayBlockOffset,
+            BigInteger syncBlockLimit) {
+        super(
+                initialBlock,
+                confirmationBlocks,
+                missingTxRetryBlocks,
+                eventInvalidationBlockThreshold,
+                replayBlockOffset,
+                syncBlockLimit);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/repository/filter/FilterEntityRepository.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/repository/filter/FilterEntityRepository.java
@@ -5,4 +5,4 @@ import java.util.UUID;
 import io.naryo.infrastructure.configuration.persistence.entity.filter.FilterEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FilterRepository extends JpaRepository<FilterEntity, UUID> {}
+public interface FilterEntityRepository extends JpaRepository<FilterEntity, UUID> {}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/repository/node/NodeEntityRepository.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/repository/node/NodeEntityRepository.java
@@ -1,0 +1,8 @@
+package io.naryo.infrastructure.configuration.persistence.repository.node;
+
+import java.util.UUID;
+
+import io.naryo.infrastructure.configuration.persistence.entity.node.NodeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NodeEntityRepository extends JpaRepository<NodeEntity, UUID> {}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/provider/filter/JpaFilterSourceProvider.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/provider/filter/JpaFilterSourceProvider.java
@@ -7,15 +7,15 @@ import java.util.List;
 import io.naryo.application.configuration.source.model.filter.FilterDescriptor;
 import io.naryo.application.filter.configuration.provider.FilterSourceProvider;
 import io.naryo.infrastructure.configuration.persistence.entity.filter.FilterEntity;
-import io.naryo.infrastructure.configuration.persistence.repository.filter.FilterRepository;
+import io.naryo.infrastructure.configuration.persistence.repository.filter.FilterEntityRepository;
 import org.springframework.stereotype.Component;
 
 @Component
 public class JpaFilterSourceProvider implements FilterSourceProvider {
 
-    private final FilterRepository repository;
+    private final FilterEntityRepository repository;
 
-    public JpaFilterSourceProvider(FilterRepository repository) {
+    public JpaFilterSourceProvider(FilterEntityRepository repository) {
         this.repository = repository;
     }
 

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/provider/node/JpaNodeSourceProvider.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/provider/node/JpaNodeSourceProvider.java
@@ -1,0 +1,32 @@
+package io.naryo.infrastructure.configuration.provider.node;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+import io.naryo.application.configuration.source.model.node.NodeDescriptor;
+import io.naryo.application.node.configuration.provider.NodeSourceProvider;
+import io.naryo.infrastructure.configuration.persistence.entity.node.NodeEntity;
+import io.naryo.infrastructure.configuration.persistence.repository.node.NodeEntityRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JpaNodeSourceProvider implements NodeSourceProvider {
+
+    private final NodeEntityRepository repository;
+
+    public JpaNodeSourceProvider(NodeEntityRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public Collection<NodeDescriptor> load() {
+        List<NodeEntity> nodes = this.repository.findAll();
+        return new HashSet<>(nodes);
+    }
+
+    @Override
+    public int priority() {
+        return 0;
+    }
+}


### PR DESCRIPTION
This PR introduces the Node domain implementation in the persistence-spring-jpa module, enabling storage and retrieval of Node configurations via JPA.

### Key changes
- Node JPA model
    - Adds a NodeEntity hierarchy using single-table inheritance with a discriminator column (node_type).
    - Adds a ConnectionEntity hierarchy (single-table, discriminator connection_type) for HTTP and WS connections.
    - Introduces embeddables for connection details:
        - ConnectionEndpointEntity (URL)
        - NodeConnectionRetryEntity (times, backoff) with sensible defaults when not provided.
    - Adds Poll and Pub/Sub block subscription entities with default values for block-related settings when absent.
    - Adds Ethereum RPC and Hedera Mirror Node block interaction entities.

    - Introduces NodeEntityRepository (Spring Data JPA).
    - Adds JpaNodeSourceProvider to expose persisted nodes as descriptors for the application layer.

### Side changes for consistency alignments

  - Renames some broadcaster-related JPA column names for clarity and consistency (e.g., type -> broadcaster_type, schema_type), keeping naming homogeneous across modules and prevent collisions between discriminator columns (used by single-table inheritance) and regular column names.
