### PR TITLE
chore: Remove unneeded properties from MongoDB documents

### DIFF
--- a/docs/configuration/configuration-mongo.md
+++ b/docs/configuration/configuration-mongo.md
@@ -531,13 +531,10 @@ collection. Stores are **per node** (the document `_id` equals the **Node ID**).
 {
   "_class": "active_event_store",
   "_id": "550e8400-e29b-41d4-a716-446655440000",
-  "state": "ACTIVE",
   "type": "MONGO",
   "features": {
     "EVENT": {
       "_class": "block_event_store",
-      "type": "EVENT",
-      "strategy": "BLOCK",
       "targets": [
         {
           "type": "BLOCK",
@@ -551,7 +548,6 @@ collection. Stores are **per node** (the document `_id` equals the **Node ID**).
     },
     "FILTER_SYNC": {
       "_class": "filter_store",
-      "type": "FILTER_SYNC",
       "destination": "/filters"
     }
   },
@@ -579,8 +575,7 @@ collection. Stores are **per node** (the document `_id` equals the **Node ID**).
 ```json
 {
   "_class": "inactive_event_store",
-  "_id": "cad022c2-3e41-426f-bb82-c0b86d58d675",
-  "state": "INACTIVE"
+  "_id": "cad022c2-3e41-426f-bb82-c0b86d58d675"
 }
 ```
 
@@ -605,7 +600,6 @@ collection. Stores are **per node** (the document `_id` equals the **Node ID**).
 |-----------------------------------|---------------|:--------:|----------------------|------------------------------------------------------------|
 | `_class`                          | string        |    ✅     | —                    | `active_event_store` \| `inactive_event_store`             |
 | `_id`                             | string (UUID) |    ✅     | —                    | **Node ID**. Used as Mongo `_id`.                          |
-| `state`                           | string (enum) |    ✅     | —                    | `ACTIVE` \| `INACTIVE`.                                    |
 | `type` *(active)*                 | string        |    ✅     | —                    | Store type (string form of `StoreType`, e.g., `"MONGO"`).  |
 | `features` *(active)*             | object (map)  |    ❌     | —                    | Map `StoreFeatureType` → feature doc (see below).          |
 
@@ -616,8 +610,6 @@ collection. Stores are **per node** (the document `_id` equals the **Node ID**).
 | Path       | Type          | Required | Default (if omitted) | Notes                                     |
 |------------|---------------|:--------:|----------------------|-------------------------------------------|
 | `_class`   | string        |    ✅     | —                    | `block_event_store`.                      |
-| `type`     | string (enum) |    ✅     | —                    | Always `EVENT` (from `StoreFeatureType`). |
-| `strategy` | string (enum) |    ✅     | —                    | `EventStoreStrategy` (e.g., `BLOCK`).     |
 | `targets`  | array<object> |    ❌     | —                    | Set of target descriptors.                |
 
 **Target descriptor**
@@ -632,7 +624,6 @@ collection. Stores are **per node** (the document `_id` equals the **Node ID**).
 | Path          | Type          | Required | Default (if omitted) | Notes                                           |
 |---------------|---------------|:--------:|----------------------|-------------------------------------------------|
 | `_class`      | string        |    ✅     | —                    | `filter_store`.                                 |
-| `type`        | string (enum) |    ✅     | —                    | Always `FILTER_SYNC` (from `StoreFeatureType`). |
 | `destination` | string        |    ❌     | —                    | Optional destination for filter-sync output.    |
 
 ---

--- a/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/store/ActiveStoreConfigurationPropertiesDocument.java
+++ b/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/store/ActiveStoreConfigurationPropertiesDocument.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 import io.naryo.application.configuration.source.definition.ConfigurationSchema;
 import io.naryo.application.configuration.source.model.store.ActiveStoreConfigurationDescriptor;
 import io.naryo.application.configuration.source.model.store.StoreFeatureConfigurationDescriptor;
-import io.naryo.domain.configuration.store.StoreState;
 import io.naryo.domain.configuration.store.active.StoreType;
 import io.naryo.domain.configuration.store.active.feature.StoreFeatureType;
 import io.naryo.infrastructure.configuration.persistence.document.common.ConfigurationSchemaDocument;
@@ -29,7 +28,7 @@ public class ActiveStoreConfigurationPropertiesDocument extends StoreConfigurati
             Map<StoreFeatureType, StoreFeatureConfigurationPropertiesDocument> features,
             Map<String, Object> additionalProperties,
             @Nullable ConfigurationSchemaDocument propertiesSchema) {
-        super(nodeId, StoreState.ACTIVE);
+        super(nodeId);
         this.type = type;
         this.features = features;
         this.additionalProperties = additionalProperties;

--- a/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/store/InactiveStoreConfigurationPropertiesDocument.java
+++ b/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/store/InactiveStoreConfigurationPropertiesDocument.java
@@ -1,13 +1,14 @@
 package io.naryo.infrastructure.configuration.persistence.document.store;
 
-import io.naryo.domain.configuration.store.StoreState;
+import io.naryo.application.configuration.source.model.store.InactiveStoreConfigurationDescriptor;
 import org.springframework.data.annotation.TypeAlias;
 
 @TypeAlias("inactive_event_store")
 public final class InactiveStoreConfigurationPropertiesDocument
-        extends StoreConfigurationPropertiesDocument {
+        extends StoreConfigurationPropertiesDocument
+        implements InactiveStoreConfigurationDescriptor {
 
     public InactiveStoreConfigurationPropertiesDocument(String nodeId) {
-        super(nodeId, StoreState.INACTIVE);
+        super(nodeId);
     }
 }

--- a/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/store/StoreConfigurationPropertiesDocument.java
+++ b/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/store/StoreConfigurationPropertiesDocument.java
@@ -3,8 +3,6 @@ package io.naryo.infrastructure.configuration.persistence.document.store;
 import java.util.UUID;
 
 import io.naryo.application.configuration.source.model.store.StoreConfigurationDescriptor;
-import io.naryo.domain.configuration.store.StoreState;
-import jakarta.validation.constraints.NotNull;
 import lombok.Setter;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.MongoId;
@@ -13,20 +11,13 @@ import org.springframework.data.mongodb.core.mapping.MongoId;
 @Setter
 public abstract class StoreConfigurationPropertiesDocument implements StoreConfigurationDescriptor {
     private @MongoId String nodeId;
-    private @NotNull StoreState state;
 
-    public StoreConfigurationPropertiesDocument(String nodeId, StoreState state) {
+    public StoreConfigurationPropertiesDocument(String nodeId) {
         this.nodeId = nodeId;
-        this.state = state;
     }
 
     @Override
     public UUID getNodeId() {
         return UUID.fromString(this.nodeId);
-    }
-
-    @Override
-    public StoreState getState() {
-        return this.state;
     }
 }

--- a/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/store/StoreFeatureConfigurationPropertiesDocument.java
+++ b/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/store/StoreFeatureConfigurationPropertiesDocument.java
@@ -1,16 +1,8 @@
 package io.naryo.infrastructure.configuration.persistence.document.store;
 
 import io.naryo.application.configuration.source.model.store.StoreFeatureConfigurationDescriptor;
-import io.naryo.domain.configuration.store.active.feature.StoreFeatureType;
 import lombok.Getter;
 
 @Getter
 public abstract class StoreFeatureConfigurationPropertiesDocument
-        implements StoreFeatureConfigurationDescriptor {
-
-    private final StoreFeatureType type;
-
-    protected StoreFeatureConfigurationPropertiesDocument(StoreFeatureType type) {
-        this.type = type;
-    }
-}
+        implements StoreFeatureConfigurationDescriptor {}

--- a/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/store/event/EventStoreConfigurationPropertiesDocument.java
+++ b/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/store/event/EventStoreConfigurationPropertiesDocument.java
@@ -1,18 +1,10 @@
 package io.naryo.infrastructure.configuration.persistence.document.store.event;
 
-import io.naryo.domain.configuration.store.active.feature.StoreFeatureType;
-import io.naryo.domain.configuration.store.active.feature.event.EventStoreStrategy;
+import io.naryo.application.configuration.source.model.store.event.EventStoreConfigurationDescriptor;
 import io.naryo.infrastructure.configuration.persistence.document.store.StoreFeatureConfigurationPropertiesDocument;
 import lombok.Getter;
 
 @Getter
 public abstract class EventStoreConfigurationPropertiesDocument
-        extends StoreFeatureConfigurationPropertiesDocument {
-
-    private final EventStoreStrategy strategy;
-
-    protected EventStoreConfigurationPropertiesDocument(EventStoreStrategy strategy) {
-        super(StoreFeatureType.EVENT);
-        this.strategy = strategy;
-    }
-}
+        extends StoreFeatureConfigurationPropertiesDocument
+        implements EventStoreConfigurationDescriptor {}

--- a/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/store/event/block/BlockStoreConfigurationPropertiesDocument.java
+++ b/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/store/event/block/BlockStoreConfigurationPropertiesDocument.java
@@ -5,7 +5,6 @@ import java.util.Set;
 
 import io.naryo.application.configuration.source.model.store.event.BlockEventStoreConfigurationDescriptor;
 import io.naryo.application.configuration.source.model.store.event.EventStoreTargetDescriptor;
-import io.naryo.domain.configuration.store.active.feature.event.EventStoreStrategy;
 import io.naryo.infrastructure.configuration.persistence.document.store.event.EventStoreConfigurationPropertiesDocument;
 import lombok.Getter;
 import org.springframework.data.annotation.TypeAlias;
@@ -22,7 +21,6 @@ public final class BlockStoreConfigurationPropertiesDocument
 
     public BlockStoreConfigurationPropertiesDocument(
             Set<EventStoreTargetPropertiesDocument> targets) {
-        super(EventStoreStrategy.BLOCK_BASED);
         this.targets = targets;
     }
 

--- a/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/store/filter/FilterStoreConfigurationPropertiesDocument.java
+++ b/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/store/filter/FilterStoreConfigurationPropertiesDocument.java
@@ -3,7 +3,6 @@ package io.naryo.infrastructure.configuration.persistence.document.store.filter;
 import java.util.Optional;
 
 import io.naryo.application.configuration.source.model.store.filter.FilterStoreConfigurationDescriptor;
-import io.naryo.domain.configuration.store.active.feature.StoreFeatureType;
 import io.naryo.infrastructure.configuration.persistence.document.store.StoreFeatureConfigurationPropertiesDocument;
 import jakarta.annotation.Nullable;
 import org.springframework.data.annotation.TypeAlias;
@@ -16,7 +15,6 @@ public final class FilterStoreConfigurationPropertiesDocument
     private @Nullable String destination;
 
     public FilterStoreConfigurationPropertiesDocument(@Nullable String destination) {
-        super(StoreFeatureType.FILTER_SYNC);
         this.destination = destination;
     }
 


### PR DESCRIPTION
- `EventStoreConfigurationPropertiesDocument`
    - Make it implement `EventStoreConfigurationDescriptor`
    - Remove `strategy` property to follow convention (hardcoded in the inheriting classes' descriptors)
- Under `StoreFeatureConfigurationPropertiesDocument`, remove `type` property to follow convention (hardcoded in the inheriting classes' descriptors)
- Under `StoreConfigurationPropertiesDocument`, remove `state` property to follow convention (hardcoded in the inheriting classes' descriptors)
- Update `configuration-mongo.md` to adapt to new documents