### PR TITLE
Chore: implement http client domain in jpa mopdule

### DIFF
--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/http/HttpClientEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/http/HttpClientEntity.java
@@ -1,0 +1,78 @@
+package io.naryo.infrastructure.configuration.persistence.entity.http;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+
+import io.naryo.application.configuration.source.model.http.HttpClientDescriptor;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Entity
+@Table(name = "http_client")
+@NoArgsConstructor
+public final class HttpClientEntity implements HttpClientDescriptor {
+
+    private @Column(name = "id") @Id UUID id;
+
+    private @Column(name = "max_idle_connections") Integer maxIdleConnections;
+
+    private @Column(name = "keep_alive_duration") Duration keepAliveDuration;
+
+    private @Column(name = "connect_timeout") Duration connectTimeout;
+
+    private @Column(name = "read_timeout") Duration readTimeout;
+
+    private @Column(name = "write_timeout") Duration writeTimeout;
+
+    private @Column(name = "call_timeout") Duration callTimeout;
+
+    private @Column(name = "ping_interval") Duration pingInterval;
+
+    private @Column(name = "retry_on_connection_failure") Boolean retryOnConnectionFailure;
+
+    @Override
+    public Optional<Integer> getMaxIdleConnections() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Duration> getKeepAliveDuration() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Duration> getConnectTimeout() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Duration> getReadTimeout() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Duration> getWriteTimeout() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Duration> getCallTimeout() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Duration> getPingInterval() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Boolean> getRetryOnConnectionFailure() {
+        return Optional.empty();
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/http/HttpClientEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/http/HttpClientEntity.java
@@ -38,41 +38,41 @@ public final class HttpClientEntity implements HttpClientDescriptor {
 
     @Override
     public Optional<Integer> getMaxIdleConnections() {
-        return Optional.empty();
+        return Optional.ofNullable(maxIdleConnections);
     }
 
     @Override
     public Optional<Duration> getKeepAliveDuration() {
-        return Optional.empty();
+        return Optional.ofNullable(this.keepAliveDuration);
     }
 
     @Override
     public Optional<Duration> getConnectTimeout() {
-        return Optional.empty();
+        return Optional.ofNullable(this.connectTimeout);
     }
 
     @Override
     public Optional<Duration> getReadTimeout() {
-        return Optional.empty();
+        return Optional.ofNullable(this.readTimeout);
     }
 
     @Override
     public Optional<Duration> getWriteTimeout() {
-        return Optional.empty();
+        return Optional.ofNullable(this.writeTimeout);
     }
 
     @Override
     public Optional<Duration> getCallTimeout() {
-        return Optional.empty();
+        return Optional.ofNullable(this.callTimeout);
     }
 
     @Override
     public Optional<Duration> getPingInterval() {
-        return Optional.empty();
+        return Optional.ofNullable(this.pingInterval);
     }
 
     @Override
     public Optional<Boolean> getRetryOnConnectionFailure() {
-        return Optional.empty();
+        return Optional.ofNullable(this.retryOnConnectionFailure);
     }
 }

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/repository/http/HttpClientEntityRepository.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/repository/http/HttpClientEntityRepository.java
@@ -1,0 +1,8 @@
+package io.naryo.infrastructure.configuration.persistence.repository.http;
+
+import java.util.UUID;
+
+import io.naryo.infrastructure.configuration.persistence.entity.http.HttpClientEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HttpClientEntityRepository extends JpaRepository<HttpClientEntity, UUID> {}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/provider/http/JpaHttpClientSourceProvider.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/provider/http/JpaHttpClientSourceProvider.java
@@ -1,0 +1,26 @@
+package io.naryo.infrastructure.configuration.provider.http;
+
+import io.naryo.application.configuration.source.model.http.HttpClientDescriptor;
+import io.naryo.application.http.configuration.provider.HttpClientSourceProvider;
+import io.naryo.infrastructure.configuration.persistence.repository.http.HttpClientEntityRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JpaHttpClientSourceProvider implements HttpClientSourceProvider {
+
+    private final HttpClientEntityRepository repository;
+
+    public JpaHttpClientSourceProvider(HttpClientEntityRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public HttpClientDescriptor load() {
+        return repository.findAll().stream().findFirst().orElse(null);
+    }
+
+    @Override
+    public int priority() {
+        return 0;
+    }
+}


### PR DESCRIPTION
This PR has already been approved: [#73](https://github.com/LF-Decentralized-Trust-labs/Naryo/pull/73).

However, the merge into the target branch failed due to nested branching and inccorect sequence of merges.