### PR TITLE
chore: Add domain fingerprinters

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation "org.web3j:besu:${web3jVersion}"
     implementation "org.bouncycastle:bcprov-jdk15on:$bcprovVersion"
     implementation "jakarta.annotation:jakarta.annotation-api:$jakartaAnnotationVersion"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
 
     compileOnly 'org.projectlombok:lombok'
 

--- a/core/src/main/java/io/naryo/application/broadcaster/configuration/normalization/BroadcasterConfigurationNormalizerRegistry.java
+++ b/core/src/main/java/io/naryo/application/broadcaster/configuration/normalization/BroadcasterConfigurationNormalizerRegistry.java
@@ -1,0 +1,72 @@
+package io.naryo.application.broadcaster.configuration.normalization;
+
+import java.util.*;
+
+import io.naryo.application.configuration.normalization.ConfigurationNormalizerRegistry;
+import io.naryo.domain.configuration.broadcaster.BroadcasterConfiguration;
+import io.naryo.domain.normalization.Normalizer;
+
+public final class BroadcasterConfigurationNormalizerRegistry
+        implements ConfigurationNormalizerRegistry<BroadcasterConfiguration> {
+
+    private final Map<String, Map<Class<?>, Normalizer<BroadcasterConfiguration>>> registry =
+            new HashMap<>();
+
+    @Override
+    public <S> void register(
+            String type, Class<S> sourceClass, Normalizer<BroadcasterConfiguration> normalizer) {
+        registry.computeIfAbsent(type.toLowerCase(), __ -> new HashMap<>())
+                .put(sourceClass, normalizer);
+    }
+
+    @Override
+    public <S> BroadcasterConfiguration normalize(String type, S source) {
+        var typeRegistry = registry.getOrDefault(type.toLowerCase(), Map.of());
+        Class<?> sourceClass = source.getClass();
+
+        Normalizer<BroadcasterConfiguration> normalizer =
+                findCompatibleNormalizer(typeRegistry, sourceClass);
+
+        if (normalizer == null) {
+            return (BroadcasterConfiguration) source;
+        }
+
+        return normalizer.normalize((BroadcasterConfiguration) source);
+    }
+
+    private Normalizer<BroadcasterConfiguration> findCompatibleNormalizer(
+            Map<Class<?>, Normalizer<BroadcasterConfiguration>> typeRegistry,
+            Class<?> sourceClass) {
+
+        Normalizer<BroadcasterConfiguration> normalizer = typeRegistry.get(sourceClass);
+        if (normalizer != null) return normalizer;
+
+        for (Class<?> clazz : getAllTypes(sourceClass)) {
+            normalizer = typeRegistry.get(clazz);
+            if (normalizer != null) return normalizer;
+        }
+
+        return null;
+    }
+
+    private Set<Class<?>> getAllTypes(Class<?> clazz) {
+        Set<Class<?>> result = new LinkedHashSet<>();
+        Queue<Class<?>> queue = new LinkedList<>();
+        queue.add(clazz);
+
+        while (!queue.isEmpty()) {
+            Class<?> current = queue.poll();
+            Class<?> superclass = current.getSuperclass();
+            if (superclass != null && result.add(superclass)) {
+                queue.add(superclass);
+            }
+            for (Class<?> iface : current.getInterfaces()) {
+                if (result.add(iface)) {
+                    queue.add(iface);
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/core/src/main/java/io/naryo/application/broadcaster/configuration/revision/BroadcasterConfigurationRevisionFingerprinter.java
+++ b/core/src/main/java/io/naryo/application/broadcaster/configuration/revision/BroadcasterConfigurationRevisionFingerprinter.java
@@ -1,0 +1,14 @@
+package io.naryo.application.broadcaster.configuration.revision;
+
+import io.naryo.application.common.revision.DefaultRevisionFingerprinter;
+import io.naryo.domain.configuration.broadcaster.BroadcasterConfiguration;
+import io.naryo.domain.configuration.broadcaster.BroadcasterConfigurationNormalizer;
+
+public final class BroadcasterConfigurationRevisionFingerprinter
+        extends DefaultRevisionFingerprinter<BroadcasterConfiguration> {
+
+    public BroadcasterConfigurationRevisionFingerprinter(
+            BroadcasterConfigurationNormalizer normalizer) {
+        super(normalizer);
+    }
+}

--- a/core/src/main/java/io/naryo/application/broadcaster/revision/BroadcasterRevisionFingerprinter.java
+++ b/core/src/main/java/io/naryo/application/broadcaster/revision/BroadcasterRevisionFingerprinter.java
@@ -1,0 +1,17 @@
+package io.naryo.application.broadcaster.revision;
+
+import io.naryo.application.common.revision.DefaultRevisionFingerprinter;
+import io.naryo.domain.broadcaster.Broadcaster;
+import io.naryo.domain.broadcaster.BroadcasterNormalizer;
+
+public final class BroadcasterRevisionFingerprinter
+        extends DefaultRevisionFingerprinter<Broadcaster> {
+
+    public BroadcasterRevisionFingerprinter() {
+        this(BroadcasterNormalizer.INSTANCE);
+    }
+
+    BroadcasterRevisionFingerprinter(BroadcasterNormalizer normalizer) {
+        super(normalizer);
+    }
+}

--- a/core/src/main/java/io/naryo/application/common/revision/CanonicalJson.java
+++ b/core/src/main/java/io/naryo/application/common/revision/CanonicalJson.java
@@ -1,0 +1,25 @@
+package io.naryo.application.common.revision;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public final class CanonicalJson {
+    private static final ObjectMapper M =
+            new ObjectMapper()
+                    .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+                    .registerModule(new JavaTimeModule())
+                    .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+    private CanonicalJson() {}
+
+    public static String write(Object value) {
+        try {
+            return M.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to render canonical JSON", e);
+        }
+    }
+}

--- a/core/src/main/java/io/naryo/application/common/revision/DefaultRevisionFingerprinter.java
+++ b/core/src/main/java/io/naryo/application/common/revision/DefaultRevisionFingerprinter.java
@@ -1,0 +1,49 @@
+package io.naryo.application.common.revision;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import io.naryo.application.common.util.EncryptionUtil;
+import io.naryo.domain.normalization.Normalizer;
+
+public abstract class DefaultRevisionFingerprinter<T> implements RevisionFingerprinter<T> {
+
+    private final Normalizer<T> normalizer;
+
+    protected DefaultRevisionFingerprinter(Normalizer<T> normalizer) {
+        this.normalizer = normalizer;
+    }
+
+    @Override
+    public String itemHash(T item) {
+        Objects.requireNonNull(item, "item cannot be null");
+        T normalized = normalizer.normalize(item);
+        String canonicalJson = CanonicalJson.write(normalized);
+        return EncryptionUtil.sha3String(canonicalJson);
+    }
+
+    @Override
+    public String revisionHash(List<T> items, Function<T, UUID> idFn) {
+        Objects.requireNonNull(items, "items cannot be null");
+        Objects.requireNonNull(idFn, "idFn cannot be null");
+
+        var lines =
+                items.stream()
+                        .map(
+                                it -> {
+                                    var id =
+                                            Objects.requireNonNull(
+                                                    idFn.apply(it), "idFn returned null");
+                                    var h = itemHash(it);
+                                    return id + ":" + h;
+                                })
+                        .sorted(Comparator.naturalOrder())
+                        .collect(Collectors.joining("\n"));
+
+        return EncryptionUtil.sha3String(lines);
+    }
+}

--- a/core/src/main/java/io/naryo/application/common/revision/RevisionFingerprinter.java
+++ b/core/src/main/java/io/naryo/application/common/revision/RevisionFingerprinter.java
@@ -1,0 +1,12 @@
+package io.naryo.application.common.revision;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+
+public interface RevisionFingerprinter<T> {
+
+    String itemHash(T item);
+
+    String revisionHash(List<T> items, Function<T, UUID> idFn);
+}

--- a/core/src/main/java/io/naryo/application/configuration/normalization/ConfigurationNormalizerRegistry.java
+++ b/core/src/main/java/io/naryo/application/configuration/normalization/ConfigurationNormalizerRegistry.java
@@ -1,0 +1,11 @@
+package io.naryo.application.configuration.normalization;
+
+import io.naryo.domain.configuration.Configuration;
+import io.naryo.domain.normalization.Normalizer;
+
+public interface ConfigurationNormalizerRegistry<T extends Configuration> {
+
+    <S> void register(String type, Class<S> sourceClass, Normalizer<T> normalizer);
+
+    <S> T normalize(String type, S source);
+}

--- a/core/src/main/java/io/naryo/application/filter/revision/FilterRevisionFingerprinter.java
+++ b/core/src/main/java/io/naryo/application/filter/revision/FilterRevisionFingerprinter.java
@@ -1,0 +1,16 @@
+package io.naryo.application.filter.revision;
+
+import io.naryo.application.common.revision.DefaultRevisionFingerprinter;
+import io.naryo.domain.filter.Filter;
+import io.naryo.domain.filter.FilterNormalizer;
+
+public final class FilterRevisionFingerprinter extends DefaultRevisionFingerprinter<Filter> {
+
+    public FilterRevisionFingerprinter(FilterNormalizer normalizer) {
+        super(normalizer);
+    }
+
+    public FilterRevisionFingerprinter() {
+        super(FilterNormalizer.INSTANCE);
+    }
+}

--- a/core/src/main/java/io/naryo/application/node/revision/NodeRevisionFingerprinter.java
+++ b/core/src/main/java/io/naryo/application/node/revision/NodeRevisionFingerprinter.java
@@ -1,0 +1,16 @@
+package io.naryo.application.node.revision;
+
+import io.naryo.application.common.revision.DefaultRevisionFingerprinter;
+import io.naryo.domain.node.Node;
+import io.naryo.domain.node.NodeNormalizer;
+
+public final class NodeRevisionFingerprinter extends DefaultRevisionFingerprinter<Node> {
+
+    public NodeRevisionFingerprinter() {
+        super(NodeNormalizer.INSTANCE);
+    }
+
+    public NodeRevisionFingerprinter(NodeNormalizer normalizer) {
+        super(normalizer);
+    }
+}

--- a/core/src/main/java/io/naryo/application/store/configuration/normalization/ActiveStoreConfigurationNormalizerRegistry.java
+++ b/core/src/main/java/io/naryo/application/store/configuration/normalization/ActiveStoreConfigurationNormalizerRegistry.java
@@ -1,0 +1,72 @@
+package io.naryo.application.store.configuration.normalization;
+
+import java.util.*;
+
+import io.naryo.application.configuration.normalization.ConfigurationNormalizerRegistry;
+import io.naryo.domain.configuration.store.active.ActiveStoreConfiguration;
+import io.naryo.domain.normalization.Normalizer;
+
+public final class ActiveStoreConfigurationNormalizerRegistry
+        implements ConfigurationNormalizerRegistry<ActiveStoreConfiguration> {
+
+    private final Map<String, Map<Class<?>, Normalizer<ActiveStoreConfiguration>>> registry =
+            new HashMap<>();
+
+    @Override
+    public <S> void register(
+            String type, Class<S> sourceClass, Normalizer<ActiveStoreConfiguration> normalizer) {
+        registry.computeIfAbsent(type.toLowerCase(), __ -> new HashMap<>())
+                .put(sourceClass, normalizer);
+    }
+
+    @Override
+    public <S> ActiveStoreConfiguration normalize(String type, S source) {
+        var typeRegistry = registry.getOrDefault(type.toLowerCase(), Map.of());
+        Class<?> sourceClass = source.getClass();
+
+        Normalizer<ActiveStoreConfiguration> normalizer =
+                findCompatibleNormalizer(typeRegistry, sourceClass);
+
+        if (normalizer == null) {
+            return (ActiveStoreConfiguration) source;
+        }
+
+        return normalizer.normalize((ActiveStoreConfiguration) source);
+    }
+
+    private Normalizer<ActiveStoreConfiguration> findCompatibleNormalizer(
+            Map<Class<?>, Normalizer<ActiveStoreConfiguration>> typeRegistry,
+            Class<?> sourceClass) {
+
+        Normalizer<ActiveStoreConfiguration> normalizer = typeRegistry.get(sourceClass);
+        if (normalizer != null) return normalizer;
+
+        for (Class<?> clazz : getAllTypes(sourceClass)) {
+            normalizer = typeRegistry.get(clazz);
+            if (normalizer != null) return normalizer;
+        }
+
+        return null;
+    }
+
+    private Set<Class<?>> getAllTypes(Class<?> clazz) {
+        Set<Class<?>> result = new LinkedHashSet<>();
+        Queue<Class<?>> queue = new LinkedList<>();
+        queue.add(clazz);
+
+        while (!queue.isEmpty()) {
+            Class<?> current = queue.poll();
+            Class<?> superclass = current.getSuperclass();
+            if (superclass != null && result.add(superclass)) {
+                queue.add(superclass);
+            }
+            for (Class<?> iface : current.getInterfaces()) {
+                if (result.add(iface)) {
+                    queue.add(iface);
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/core/src/main/java/io/naryo/application/store/revision/StoreRevisionFingerprinter.java
+++ b/core/src/main/java/io/naryo/application/store/revision/StoreRevisionFingerprinter.java
@@ -1,0 +1,13 @@
+package io.naryo.application.store.revision;
+
+import io.naryo.application.common.revision.DefaultRevisionFingerprinter;
+import io.naryo.domain.configuration.store.StoreConfiguration;
+import io.naryo.domain.configuration.store.StoreConfigurationNormalizer;
+
+public final class StoreRevisionFingerprinter
+        extends DefaultRevisionFingerprinter<StoreConfiguration> {
+
+    public StoreRevisionFingerprinter(StoreConfigurationNormalizer normalizer) {
+        super(normalizer);
+    }
+}

--- a/core/src/main/java/io/naryo/domain/broadcaster/Broadcaster.java
+++ b/core/src/main/java/io/naryo/domain/broadcaster/Broadcaster.java
@@ -3,9 +3,11 @@ package io.naryo.domain.broadcaster;
 import java.util.Objects;
 import java.util.UUID;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder(toBuilder = true)
 public class Broadcaster {
 
     private final UUID id;

--- a/core/src/main/java/io/naryo/domain/broadcaster/BroadcasterNormalizer.java
+++ b/core/src/main/java/io/naryo/domain/broadcaster/BroadcasterNormalizer.java
@@ -1,0 +1,70 @@
+package io.naryo.domain.broadcaster;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+import io.naryo.domain.broadcaster.target.*;
+import io.naryo.domain.common.Destination;
+import io.naryo.domain.common.normalization.NormalizationUtil;
+import io.naryo.domain.normalization.Normalizer;
+
+public final class BroadcasterNormalizer implements Normalizer<Broadcaster> {
+
+    public static final BroadcasterNormalizer INSTANCE = new BroadcasterNormalizer();
+
+    public BroadcasterNormalizer() {}
+
+    @Override
+    public Broadcaster normalize(Broadcaster in) {
+        if (in == null) {
+            return null;
+        }
+
+        var builder = in.toBuilder();
+
+        BroadcasterTarget target =
+                switch (in.getTarget()) {
+                    case AllBroadcasterTarget allIn ->
+                            allIn.toBuilder()
+                                    .destinations(normalize(allIn.getDestinations()))
+                                    .build();
+                    case BlockBroadcasterTarget blockIn ->
+                            blockIn.toBuilder()
+                                    .destinations(normalize(blockIn.getDestinations()))
+                                    .build();
+                    case ContractEventBroadcasterTarget ceIn ->
+                            ceIn.toBuilder()
+                                    .destinations(normalize(ceIn.getDestinations()))
+                                    .build();
+                    case TransactionBroadcasterTarget taIn ->
+                            taIn.toBuilder()
+                                    .destinations(normalize(taIn.getDestinations()))
+                                    .build();
+                    case FilterEventBroadcasterTarget feIn ->
+                            feIn.toBuilder()
+                                    .destinations(normalize(feIn.getDestinations()))
+                                    .build();
+                    default ->
+                            throw new IllegalStateException("Unexpected value: " + in.getTarget());
+                };
+
+        return builder.target(target).build();
+    }
+
+    List<Destination> normalize(List<Destination> in) {
+        if (in == null) return List.of();
+        return in.stream()
+                .map(this::normalize)
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparing(Destination::value, Comparator.naturalOrder()))
+                .toList();
+    }
+
+    Destination normalize(Destination in) {
+        if (in == null || in.value() == null) {
+            return null;
+        }
+        return new Destination(NormalizationUtil.normalize(in.value()));
+    }
+}

--- a/core/src/main/java/io/naryo/domain/broadcaster/BroadcasterTarget.java
+++ b/core/src/main/java/io/naryo/domain/broadcaster/BroadcasterTarget.java
@@ -7,10 +7,12 @@ import io.naryo.domain.common.Destination;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString
 @EqualsAndHashCode
+@SuperBuilder(toBuilder = true)
 public abstract class BroadcasterTarget {
 
     protected final BroadcasterTargetType type;

--- a/core/src/main/java/io/naryo/domain/broadcaster/target/AllBroadcasterTarget.java
+++ b/core/src/main/java/io/naryo/domain/broadcaster/target/AllBroadcasterTarget.java
@@ -5,7 +5,9 @@ import java.util.List;
 import io.naryo.domain.broadcaster.BroadcasterTarget;
 import io.naryo.domain.broadcaster.BroadcasterTargetType;
 import io.naryo.domain.common.Destination;
+import lombok.experimental.SuperBuilder;
 
+@SuperBuilder(toBuilder = true)
 public final class AllBroadcasterTarget extends BroadcasterTarget {
 
     public AllBroadcasterTarget(List<Destination> destinations) {

--- a/core/src/main/java/io/naryo/domain/broadcaster/target/BlockBroadcasterTarget.java
+++ b/core/src/main/java/io/naryo/domain/broadcaster/target/BlockBroadcasterTarget.java
@@ -5,7 +5,9 @@ import java.util.List;
 import io.naryo.domain.broadcaster.BroadcasterTarget;
 import io.naryo.domain.broadcaster.BroadcasterTargetType;
 import io.naryo.domain.common.Destination;
+import lombok.experimental.SuperBuilder;
 
+@SuperBuilder(toBuilder = true)
 public final class BlockBroadcasterTarget extends BroadcasterTarget {
 
     public BlockBroadcasterTarget(List<Destination> destinations) {

--- a/core/src/main/java/io/naryo/domain/broadcaster/target/ContractEventBroadcasterTarget.java
+++ b/core/src/main/java/io/naryo/domain/broadcaster/target/ContractEventBroadcasterTarget.java
@@ -5,7 +5,9 @@ import java.util.List;
 import io.naryo.domain.broadcaster.BroadcasterTarget;
 import io.naryo.domain.broadcaster.BroadcasterTargetType;
 import io.naryo.domain.common.Destination;
+import lombok.experimental.SuperBuilder;
 
+@SuperBuilder(toBuilder = true)
 public final class ContractEventBroadcasterTarget extends BroadcasterTarget {
 
     public ContractEventBroadcasterTarget(List<Destination> destinations) {

--- a/core/src/main/java/io/naryo/domain/broadcaster/target/FilterEventBroadcasterTarget.java
+++ b/core/src/main/java/io/naryo/domain/broadcaster/target/FilterEventBroadcasterTarget.java
@@ -10,9 +10,11 @@ import io.naryo.domain.common.Destination;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
+@SuperBuilder(toBuilder = true)
 @EqualsAndHashCode(callSuper = true)
 public final class FilterEventBroadcasterTarget extends BroadcasterTarget {
 

--- a/core/src/main/java/io/naryo/domain/broadcaster/target/TransactionBroadcasterTarget.java
+++ b/core/src/main/java/io/naryo/domain/broadcaster/target/TransactionBroadcasterTarget.java
@@ -5,7 +5,9 @@ import java.util.List;
 import io.naryo.domain.broadcaster.BroadcasterTarget;
 import io.naryo.domain.broadcaster.BroadcasterTargetType;
 import io.naryo.domain.common.Destination;
+import lombok.experimental.SuperBuilder;
 
+@SuperBuilder(toBuilder = true)
 public final class TransactionBroadcasterTarget extends BroadcasterTarget {
 
     public TransactionBroadcasterTarget(List<Destination> destinations) {

--- a/core/src/main/java/io/naryo/domain/common/connection/endpoint/ConnectionEndpointNormalizer.java
+++ b/core/src/main/java/io/naryo/domain/common/connection/endpoint/ConnectionEndpointNormalizer.java
@@ -1,0 +1,79 @@
+package io.naryo.domain.common.connection.endpoint;
+
+import java.net.IDN;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import io.naryo.domain.normalization.Normalizer;
+
+public final class ConnectionEndpointNormalizer implements Normalizer<ConnectionEndpoint> {
+
+    public static final ConnectionEndpointNormalizer INSTANCE = new ConnectionEndpointNormalizer();
+    private static final Pattern MULTI_SLASH = Pattern.compile("/{2,}");
+
+    @Override
+    public ConnectionEndpoint normalize(ConnectionEndpoint in) {
+        if (in == null) return null;
+
+        final Protocol protocol = in.getProtocol();
+
+        String host = in.getHost().trim().toLowerCase(Locale.ROOT);
+        if (host.endsWith(".")) host = host.substring(0, host.length() - 1);
+
+        if (!host.chars().allMatch(c -> c < 128)) {
+            host = IDN.toASCII(host, IDN.ALLOW_UNASSIGNED);
+        }
+
+        final int port = in.getPort();
+
+        String path = normalizePathForStorage(in.getPath());
+
+        Map<String, String> headers = normalizeHeaders(in.getHeaders());
+
+        final String url = buildUrl(protocol, host, port, path);
+
+        return new ConnectionEndpoint(url, headers);
+    }
+
+    private static Map<String, String> normalizeHeaders(Map<String, String> in) {
+        if (in == null || in.isEmpty()) return Map.of();
+        TreeMap<String, String> out = new TreeMap<>();
+        for (var e : in.entrySet()) {
+            if (e.getKey() == null) continue;
+            String k = e.getKey().trim().toLowerCase(Locale.ROOT);
+            String v = e.getValue() == null ? "" : e.getValue().trim();
+            out.put(k, v);
+        }
+        return Collections.unmodifiableMap(out);
+    }
+
+    private static String normalizePathForStorage(String raw) {
+        if (raw == null || raw.isEmpty()) return "";
+        String p = MULTI_SLASH.matcher(raw).replaceAll("/");
+        p = p.replace("/./", "/");
+        Deque<String> stack = new ArrayDeque<>();
+        for (String seg : p.split("/")) {
+            if (seg.isEmpty() || seg.equals(".")) continue;
+            if (seg.equals("..")) {
+                if (!stack.isEmpty()) stack.removeLast();
+            } else stack.addLast(seg);
+        }
+        return String.join("/", stack);
+    }
+
+    private static String buildUrl(
+            Protocol protocol, String host, int port, String pathNoLeadingSlash) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(protocol.name().toLowerCase(Locale.ROOT)).append("://").append(host);
+        int defaultPort =
+                switch (protocol) {
+                    case HTTP, WS -> 80;
+                    case HTTPS, WSS -> 443;
+                };
+        if (port != defaultPort) sb.append(':').append(port);
+        if (pathNoLeadingSlash != null && !pathNoLeadingSlash.isEmpty()) {
+            sb.append('/').append(pathNoLeadingSlash);
+        }
+        return sb.toString();
+    }
+}

--- a/core/src/main/java/io/naryo/domain/common/event/EventNameNormalizer.java
+++ b/core/src/main/java/io/naryo/domain/common/event/EventNameNormalizer.java
@@ -1,0 +1,17 @@
+package io.naryo.domain.common.event;
+
+import io.naryo.domain.normalization.Normalizer;
+
+public final class EventNameNormalizer implements Normalizer<EventName> {
+
+    public static final EventNameNormalizer INSTANCE = new EventNameNormalizer();
+
+    @Override
+    public EventName normalize(EventName in) {
+        if (in == null || in.value() == null) {
+            return null;
+        }
+
+        return new EventName(in.value().trim().toLowerCase().replaceAll("[^a-z0-9_-]", ""));
+    }
+}

--- a/core/src/main/java/io/naryo/domain/common/normalization/NormalizationUtil.java
+++ b/core/src/main/java/io/naryo/domain/common/normalization/NormalizationUtil.java
@@ -1,0 +1,44 @@
+package io.naryo.domain.common.normalization;
+
+import java.text.Normalizer;
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public final class NormalizationUtil {
+
+    // ZW chars: ZWSP, ZWNJ, ZWJ, WJ, BOM
+    private static final Pattern INVISIBLES =
+            Pattern.compile("[\\u200B\\u200C\\u200D\\u2060\\uFEFF]");
+
+    private NormalizationUtil() {}
+
+    public static String normalize(String in) {
+        if (in == null) return null;
+        // lower case
+        in = in.toLowerCase(Locale.ROOT);
+        // line endings
+        in = in.replace("\r\n", "\n").replace("\r", "\n");
+        // remove BOM if present
+        if (!in.isEmpty() && in.charAt(0) == '\uFEFF') in = in.substring(1);
+        // remove zero-width
+        in = INVISIBLES.matcher(in).replaceAll("");
+        // NBSP -> space
+        in = in.replace('\u00A0', ' ');
+        // trim
+        in = in.trim();
+        return Normalizer.normalize(in, Normalizer.Form.NFC);
+    }
+
+    public static <E> LinkedHashSet<E> normalize(Set<E> in, Comparator<E> cmp) {
+        return in.stream()
+                .filter(Objects::nonNull)
+                .sorted(cmp)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    public static <E> List<E> normalize(List<E> in, Comparator<E> cmp) {
+        if (in == null) return List.of();
+        return in.stream().filter(Objects::nonNull).sorted(cmp).toList();
+    }
+}

--- a/core/src/main/java/io/naryo/domain/configuration/broadcaster/BroadcasterConfiguration.java
+++ b/core/src/main/java/io/naryo/domain/configuration/broadcaster/BroadcasterConfiguration.java
@@ -8,10 +8,12 @@ import io.naryo.domain.configuration.Configuration;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString
 @EqualsAndHashCode
+@SuperBuilder(toBuilder = true)
 public abstract class BroadcasterConfiguration implements Configuration {
 
     protected final UUID id;

--- a/core/src/main/java/io/naryo/domain/configuration/broadcaster/BroadcasterConfigurationNormalizer.java
+++ b/core/src/main/java/io/naryo/domain/configuration/broadcaster/BroadcasterConfigurationNormalizer.java
@@ -1,0 +1,23 @@
+package io.naryo.domain.configuration.broadcaster;
+
+import io.naryo.application.broadcaster.configuration.normalization.BroadcasterConfigurationNormalizerRegistry;
+import io.naryo.domain.normalization.Normalizer;
+
+public final class BroadcasterConfigurationNormalizer
+        implements Normalizer<BroadcasterConfiguration> {
+
+    private final BroadcasterConfigurationNormalizerRegistry registry;
+
+    public BroadcasterConfigurationNormalizer(BroadcasterConfigurationNormalizerRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public BroadcasterConfiguration normalize(BroadcasterConfiguration in) {
+        if (in == null) {
+            return null;
+        }
+
+        return registry.normalize(in.getType().getName(), in);
+    }
+}

--- a/core/src/main/java/io/naryo/domain/configuration/broadcaster/http/HttpBroadcasterConfiguration.java
+++ b/core/src/main/java/io/naryo/domain/configuration/broadcaster/http/HttpBroadcasterConfiguration.java
@@ -8,10 +8,12 @@ import io.naryo.domain.common.connection.endpoint.ConnectionEndpoint;
 import io.naryo.domain.configuration.broadcaster.BroadcasterCache;
 import io.naryo.domain.configuration.broadcaster.BroadcasterConfiguration;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 
 import static io.naryo.domain.HttpConstants.HTTP_TYPE;
 
 @Getter
+@SuperBuilder(toBuilder = true)
 public final class HttpBroadcasterConfiguration extends BroadcasterConfiguration {
 
     private final ConnectionEndpoint endpoint;

--- a/core/src/main/java/io/naryo/domain/configuration/store/StoreConfiguration.java
+++ b/core/src/main/java/io/naryo/domain/configuration/store/StoreConfiguration.java
@@ -5,10 +5,12 @@ import java.util.UUID;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString
 @EqualsAndHashCode
+@SuperBuilder(toBuilder = true)
 public abstract class StoreConfiguration {
 
     private final UUID nodeId;

--- a/core/src/main/java/io/naryo/domain/configuration/store/StoreConfigurationNormalizer.java
+++ b/core/src/main/java/io/naryo/domain/configuration/store/StoreConfigurationNormalizer.java
@@ -1,0 +1,22 @@
+package io.naryo.domain.configuration.store;
+
+import io.naryo.domain.configuration.store.active.ActiveStoreConfiguration;
+import io.naryo.domain.configuration.store.active.ActiveStoreConfigurationNormalizer;
+import io.naryo.domain.normalization.Normalizer;
+
+public final class StoreConfigurationNormalizer implements Normalizer<StoreConfiguration> {
+
+    private final ActiveStoreConfigurationNormalizer activeNormalizer;
+
+    public StoreConfigurationNormalizer(ActiveStoreConfigurationNormalizer activeNormalizer) {
+        this.activeNormalizer = activeNormalizer;
+    }
+
+    @Override
+    public StoreConfiguration normalize(StoreConfiguration in) {
+        return switch (in.getState()) {
+            case ACTIVE -> activeNormalizer.normalize((ActiveStoreConfiguration) in);
+            case INACTIVE -> in;
+        };
+    }
+}

--- a/core/src/main/java/io/naryo/domain/configuration/store/active/ActiveStoreConfiguration.java
+++ b/core/src/main/java/io/naryo/domain/configuration/store/active/ActiveStoreConfiguration.java
@@ -11,9 +11,11 @@ import io.naryo.domain.configuration.store.active.feature.StoreFeatureType;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString
+@SuperBuilder(toBuilder = true)
 @EqualsAndHashCode(callSuper = true)
 public abstract class ActiveStoreConfiguration extends StoreConfiguration implements Configuration {
 

--- a/core/src/main/java/io/naryo/domain/configuration/store/active/ActiveStoreConfigurationNormalizer.java
+++ b/core/src/main/java/io/naryo/domain/configuration/store/active/ActiveStoreConfigurationNormalizer.java
@@ -1,0 +1,22 @@
+package io.naryo.domain.configuration.store.active;
+
+import io.naryo.application.store.configuration.normalization.ActiveStoreConfigurationNormalizerRegistry;
+import io.naryo.domain.normalization.Normalizer;
+
+public final class ActiveStoreConfigurationNormalizer
+        implements Normalizer<ActiveStoreConfiguration> {
+
+    private final ActiveStoreConfigurationNormalizerRegistry registry;
+
+    public ActiveStoreConfigurationNormalizer(ActiveStoreConfigurationNormalizerRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public ActiveStoreConfiguration normalize(ActiveStoreConfiguration in) {
+        if (in == null) {
+            return null;
+        }
+        return registry.normalize(in.getType().getName(), in);
+    }
+}

--- a/core/src/main/java/io/naryo/domain/configuration/store/active/BaseActiveStoreNormalizer.java
+++ b/core/src/main/java/io/naryo/domain/configuration/store/active/BaseActiveStoreNormalizer.java
@@ -1,0 +1,45 @@
+package io.naryo.domain.configuration.store.active;
+
+import java.util.Comparator;
+import java.util.Map;
+
+import io.naryo.domain.common.Destination;
+import io.naryo.domain.common.normalization.NormalizationUtil;
+import io.naryo.domain.configuration.store.active.feature.StoreFeatureConfiguration;
+import io.naryo.domain.configuration.store.active.feature.StoreFeatureType;
+import io.naryo.domain.configuration.store.active.feature.event.block.BlockEventStoreConfiguration;
+import io.naryo.domain.configuration.store.active.feature.event.block.EventStoreTarget;
+import io.naryo.domain.configuration.store.active.feature.filter.FilterStoreConfiguration;
+import io.naryo.domain.normalization.Normalizer;
+
+public abstract class BaseActiveStoreNormalizer<T extends ActiveStoreConfiguration>
+        implements Normalizer<T> {
+
+    protected Map<StoreFeatureType, StoreFeatureConfiguration> normalize(
+            Map<StoreFeatureType, StoreFeatureConfiguration> in) {
+        return in.entrySet().stream()
+                .collect(
+                        java.util.stream.Collectors.toMap(
+                                Map.Entry::getKey, e -> normalizeFeature(e.getValue())));
+    }
+
+    protected StoreFeatureConfiguration normalizeFeature(StoreFeatureConfiguration in) {
+        return switch (in) {
+            case BlockEventStoreConfiguration blockIn ->
+                    blockIn.toBuilder()
+                            .targets(
+                                    NormalizationUtil.normalize(
+                                            blockIn.getTargets(),
+                                            Comparator.comparing(EventStoreTarget::type)))
+                            .build();
+            case FilterStoreConfiguration filterIn ->
+                    filterIn.toBuilder()
+                            .destination(
+                                    new Destination(
+                                            NormalizationUtil.normalize(
+                                                    filterIn.getDestination().value())))
+                            .build();
+            default -> throw new IllegalStateException("Unexpected value: " + in);
+        };
+    }
+}

--- a/core/src/main/java/io/naryo/domain/configuration/store/active/feature/StoreFeatureConfiguration.java
+++ b/core/src/main/java/io/naryo/domain/configuration/store/active/feature/StoreFeatureConfiguration.java
@@ -3,10 +3,12 @@ package io.naryo.domain.configuration.store.active.feature;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString
 @EqualsAndHashCode
+@SuperBuilder(toBuilder = true)
 public abstract class StoreFeatureConfiguration {
 
     private final StoreFeatureType type;

--- a/core/src/main/java/io/naryo/domain/configuration/store/active/feature/event/EventStoreConfiguration.java
+++ b/core/src/main/java/io/naryo/domain/configuration/store/active/feature/event/EventStoreConfiguration.java
@@ -5,9 +5,11 @@ import io.naryo.domain.configuration.store.active.feature.StoreFeatureType;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString
+@SuperBuilder(toBuilder = true)
 @EqualsAndHashCode(callSuper = true)
 public abstract class EventStoreConfiguration extends StoreFeatureConfiguration {
 

--- a/core/src/main/java/io/naryo/domain/configuration/store/active/feature/event/block/BlockEventStoreConfiguration.java
+++ b/core/src/main/java/io/naryo/domain/configuration/store/active/feature/event/block/BlockEventStoreConfiguration.java
@@ -8,9 +8,11 @@ import io.naryo.domain.configuration.store.active.feature.event.EventStoreStrate
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
+@SuperBuilder(toBuilder = true)
 @EqualsAndHashCode(callSuper = true)
 public final class BlockEventStoreConfiguration extends EventStoreConfiguration {
 

--- a/core/src/main/java/io/naryo/domain/configuration/store/active/feature/filter/FilterStoreConfiguration.java
+++ b/core/src/main/java/io/naryo/domain/configuration/store/active/feature/filter/FilterStoreConfiguration.java
@@ -6,9 +6,11 @@ import io.naryo.domain.configuration.store.active.feature.StoreFeatureType;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString
+@SuperBuilder(toBuilder = true)
 @EqualsAndHashCode(callSuper = true)
 public final class FilterStoreConfiguration extends StoreFeatureConfiguration {
 

--- a/core/src/main/java/io/naryo/domain/configuration/store/active/http/HttpStoreConfiguration.java
+++ b/core/src/main/java/io/naryo/domain/configuration/store/active/http/HttpStoreConfiguration.java
@@ -10,11 +10,13 @@ import io.naryo.domain.configuration.store.active.feature.StoreFeatureType;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 import static io.naryo.domain.HttpConstants.HTTP_TYPE;
 
 @Getter
 @ToString(callSuper = true)
+@SuperBuilder(toBuilder = true)
 @EqualsAndHashCode(callSuper = true)
 public final class HttpStoreConfiguration extends ActiveStoreConfiguration {
 

--- a/core/src/main/java/io/naryo/domain/filter/Filter.java
+++ b/core/src/main/java/io/naryo/domain/filter/Filter.java
@@ -6,9 +6,11 @@ import java.util.UUID;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString
+@SuperBuilder(toBuilder = true)
 @EqualsAndHashCode
 public abstract class Filter {
 

--- a/core/src/main/java/io/naryo/domain/filter/FilterNormalizer.java
+++ b/core/src/main/java/io/naryo/domain/filter/FilterNormalizer.java
@@ -1,0 +1,91 @@
+package io.naryo.domain.filter;
+
+import java.util.Comparator;
+import java.util.Set;
+
+import io.naryo.domain.common.TransactionStatus;
+import io.naryo.domain.common.event.ContractEventStatus;
+import io.naryo.domain.common.event.EventName;
+import io.naryo.domain.common.normalization.NormalizationUtil;
+import io.naryo.domain.filter.event.*;
+import io.naryo.domain.filter.transaction.TransactionFilter;
+import io.naryo.domain.normalization.Normalizer;
+
+public final class FilterNormalizer implements Normalizer<Filter> {
+
+    public static final FilterNormalizer INSTANCE = new FilterNormalizer();
+
+    public FilterNormalizer() {}
+
+    @Override
+    public Filter normalize(Filter in) {
+        return switch (in) {
+            case ContractEventFilter ceIn ->
+                    ceIn.toBuilder()
+                            .name(normalize(ceIn.getName()))
+                            .specification(normalize(ceIn.getSpecification()))
+                            .statuses(normalizeCs(ceIn.getStatuses()))
+                            .visibilityConfiguration(normalize(ceIn.getVisibilityConfiguration()))
+                            .contractAddress(NormalizationUtil.normalize(ceIn.getContractAddress()))
+                            .build();
+            case GlobalEventFilter geIn ->
+                    geIn.toBuilder()
+                            .name(normalize(geIn.getName()))
+                            .specification(normalize(geIn.getSpecification()))
+                            .statuses(normalizeCs(geIn.getStatuses()))
+                            .visibilityConfiguration(normalize(geIn.getVisibilityConfiguration()))
+                            .build();
+            case TransactionFilter taIn ->
+                    taIn.toBuilder()
+                            .name(normalize(taIn.name))
+                            .value(NormalizationUtil.normalize(taIn.getValue()))
+                            .statuses(normalizeTs(taIn.getStatuses()))
+                            .build();
+            default -> throw new IllegalStateException("Unexpected value: " + in);
+        };
+    }
+
+    private FilterName normalize(FilterName in) {
+        if (in == null || in.value() == null) {
+            return null;
+        }
+        return new FilterName(NormalizationUtil.normalize(in.value()));
+    }
+
+    private EventFilterSpecification normalize(EventFilterSpecification in) {
+        if (in == null) {
+            return null;
+        }
+        var builder = in.toBuilder();
+
+        builder.eventName(new EventName(NormalizationUtil.normalize(in.eventName().value())));
+        return builder.parameters(
+                        NormalizationUtil.normalize(
+                                in.parameters(),
+                                Comparator.comparingInt(ParameterDefinition::getPosition)))
+                .build();
+    }
+
+    private Set<ContractEventStatus> normalizeCs(Set<ContractEventStatus> in) {
+        if (in == null) {
+            return null;
+        }
+        return NormalizationUtil.normalize(in, Comparator.comparingInt(Enum::ordinal));
+    }
+
+    private EventFilterVisibilityConfiguration normalize(EventFilterVisibilityConfiguration in) {
+        if (in == null) {
+            return null;
+        }
+        return in.toBuilder()
+                .privacyGroupId(NormalizationUtil.normalize(in.getPrivacyGroupId()))
+                .build();
+    }
+
+    private Set<TransactionStatus> normalizeTs(Set<TransactionStatus> in) {
+        if (in == null) {
+            return null;
+        }
+        return NormalizationUtil.normalize(in, Comparator.comparingInt(Enum::ordinal));
+    }
+}

--- a/core/src/main/java/io/naryo/domain/filter/event/ContractEventFilter.java
+++ b/core/src/main/java/io/naryo/domain/filter/event/ContractEventFilter.java
@@ -9,9 +9,11 @@ import io.naryo.domain.filter.FilterName;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
+@SuperBuilder(toBuilder = true)
 @EqualsAndHashCode(callSuper = true)
 public class ContractEventFilter extends EventFilter {
 

--- a/core/src/main/java/io/naryo/domain/filter/event/EventFilter.java
+++ b/core/src/main/java/io/naryo/domain/filter/event/EventFilter.java
@@ -11,9 +11,11 @@ import io.naryo.domain.filter.FilterType;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
+@SuperBuilder(toBuilder = true)
 @EqualsAndHashCode(callSuper = true)
 public abstract class EventFilter extends Filter {
 

--- a/core/src/main/java/io/naryo/domain/filter/event/EventFilterSpecification.java
+++ b/core/src/main/java/io/naryo/domain/filter/event/EventFilterSpecification.java
@@ -5,7 +5,9 @@ import java.util.stream.Collectors;
 
 import io.naryo.domain.common.event.EventName;
 import io.naryo.domain.filter.event.parameter.*;
+import lombok.Builder;
 
+@Builder(toBuilder = true)
 public record EventFilterSpecification(
         EventName eventName, CorrelationId correlationId, Set<ParameterDefinition> parameters) {
 

--- a/core/src/main/java/io/naryo/domain/filter/event/EventFilterVisibilityConfiguration.java
+++ b/core/src/main/java/io/naryo/domain/filter/event/EventFilterVisibilityConfiguration.java
@@ -1,10 +1,12 @@
 package io.naryo.domain.filter.event;
 
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
 @EqualsAndHashCode
+@Builder(toBuilder = true)
 public class EventFilterVisibilityConfiguration {
 
     private final boolean visible;

--- a/core/src/main/java/io/naryo/domain/filter/event/GlobalEventFilter.java
+++ b/core/src/main/java/io/naryo/domain/filter/event/GlobalEventFilter.java
@@ -5,7 +5,9 @@ import java.util.UUID;
 
 import io.naryo.domain.common.event.ContractEventStatus;
 import io.naryo.domain.filter.FilterName;
+import lombok.experimental.SuperBuilder;
 
+@SuperBuilder(toBuilder = true)
 public class GlobalEventFilter extends EventFilter {
 
     public GlobalEventFilter(

--- a/core/src/main/java/io/naryo/domain/filter/transaction/TransactionFilter.java
+++ b/core/src/main/java/io/naryo/domain/filter/transaction/TransactionFilter.java
@@ -12,9 +12,11 @@ import io.naryo.domain.filter.FilterType;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
+@SuperBuilder(toBuilder = true)
 @EqualsAndHashCode(callSuper = true)
 public final class TransactionFilter extends Filter {
 

--- a/core/src/main/java/io/naryo/domain/node/Node.java
+++ b/core/src/main/java/io/naryo/domain/node/Node.java
@@ -9,10 +9,12 @@ import io.naryo.domain.node.subscription.SubscriptionConfiguration;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
 @EqualsAndHashCode(of = {"id"})
+@SuperBuilder(toBuilder = true)
 public abstract class Node {
 
     protected final UUID id;

--- a/core/src/main/java/io/naryo/domain/node/NodeNormalizer.java
+++ b/core/src/main/java/io/naryo/domain/node/NodeNormalizer.java
@@ -1,0 +1,67 @@
+package io.naryo.domain.node;
+
+import io.naryo.domain.common.normalization.NormalizationUtil;
+import io.naryo.domain.node.connection.NodeConnectionNormalizer;
+import io.naryo.domain.node.ethereum.EthereumNode;
+import io.naryo.domain.node.ethereum.priv.PrivateEthereumNode;
+import io.naryo.domain.node.ethereum.pub.PublicEthereumNode;
+import io.naryo.domain.node.hedera.HederaNode;
+import io.naryo.domain.normalization.Normalizer;
+
+public final class NodeNormalizer implements Normalizer<Node> {
+
+    public static final NodeNormalizer INSTANCE = new NodeNormalizer();
+
+    private final NodeConnectionNormalizer nodeConnectionNormalizer;
+
+    public NodeNormalizer() {
+        this(NodeConnectionNormalizer.INSTANCE);
+    }
+
+    public NodeNormalizer(NodeConnectionNormalizer nodeConnectionNormalizer) {
+        this.nodeConnectionNormalizer = nodeConnectionNormalizer;
+    }
+
+    @Override
+    public Node normalize(Node in) {
+        if (in == null) {
+            return null;
+        }
+
+        return switch (in) {
+            case EthereumNode ethIn ->
+                    switch (ethIn) {
+                        case PublicEthereumNode pubEthIn ->
+                                pubEthIn.toBuilder()
+                                        .name(normalize(pubEthIn.name))
+                                        .connection(
+                                                nodeConnectionNormalizer.normalize(
+                                                        pubEthIn.getConnection()))
+                                        .build();
+                        case PrivateEthereumNode privEthIn ->
+                                privEthIn.toBuilder()
+                                        .name(normalize(privEthIn.name))
+                                        .connection(
+                                                nodeConnectionNormalizer.normalize(
+                                                        privEthIn.getConnection()))
+                                        .build();
+                        default -> throw new IllegalStateException("Unexpected value: " + ethIn);
+                    };
+
+            case HederaNode hedIn ->
+                    hedIn.toBuilder()
+                            .name(normalize(hedIn.name))
+                            .connection(nodeConnectionNormalizer.normalize(hedIn.getConnection()))
+                            .build();
+
+            default -> throw new IllegalStateException("Unexpected value: " + in);
+        };
+    }
+
+    private NodeName normalize(NodeName in) {
+        if (in == null || in.value() == null) {
+            return null;
+        }
+        return new NodeName(NormalizationUtil.normalize(in.value()));
+    }
+}

--- a/core/src/main/java/io/naryo/domain/node/connection/NodeConnection.java
+++ b/core/src/main/java/io/naryo/domain/node/connection/NodeConnection.java
@@ -6,15 +6,17 @@ import io.naryo.domain.common.connection.endpoint.ConnectionEndpoint;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString
 @EqualsAndHashCode(callSuper = false)
+@SuperBuilder(toBuilder = true)
 public abstract class NodeConnection {
 
     private final NodeConnectionType type;
-    protected RetryConfiguration retryConfiguration;
-    protected ConnectionEndpoint endpoint;
+    protected final RetryConfiguration retryConfiguration;
+    protected final ConnectionEndpoint endpoint;
 
     protected NodeConnection(
             NodeConnectionType type,

--- a/core/src/main/java/io/naryo/domain/node/connection/NodeConnectionNormalizer.java
+++ b/core/src/main/java/io/naryo/domain/node/connection/NodeConnectionNormalizer.java
@@ -1,0 +1,40 @@
+package io.naryo.domain.node.connection;
+
+import io.naryo.domain.common.connection.endpoint.ConnectionEndpointNormalizer;
+import io.naryo.domain.node.connection.http.HttpNodeConnection;
+import io.naryo.domain.node.connection.ws.WsNodeConnection;
+import io.naryo.domain.normalization.Normalizer;
+
+public final class NodeConnectionNormalizer implements Normalizer<NodeConnection> {
+
+    public static final NodeConnectionNormalizer INSTANCE = new NodeConnectionNormalizer();
+
+    private final ConnectionEndpointNormalizer connectionEndpointNormalizer;
+
+    private NodeConnectionNormalizer() {
+        this(ConnectionEndpointNormalizer.INSTANCE);
+    }
+
+    public NodeConnectionNormalizer(ConnectionEndpointNormalizer connectionEndpointNormalizer) {
+        this.connectionEndpointNormalizer = connectionEndpointNormalizer;
+    }
+
+    @Override
+    public NodeConnection normalize(NodeConnection in) {
+        if (in == null) {
+            return null;
+        }
+
+        return switch (in) {
+            case HttpNodeConnection httpIn ->
+                    httpIn.toBuilder()
+                            .endpoint(connectionEndpointNormalizer.normalize(httpIn.getEndpoint()))
+                            .build();
+            case WsNodeConnection wsIn ->
+                    wsIn.toBuilder()
+                            .endpoint(connectionEndpointNormalizer.normalize(wsIn.getEndpoint()))
+                            .build();
+            default -> throw new IllegalStateException("Unexpected value: " + in);
+        };
+    }
+}

--- a/core/src/main/java/io/naryo/domain/node/connection/http/HttpNodeConnection.java
+++ b/core/src/main/java/io/naryo/domain/node/connection/http/HttpNodeConnection.java
@@ -10,10 +10,12 @@ import io.naryo.domain.node.connection.RetryConfiguration;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
+@SuperBuilder(toBuilder = true)
 public final class HttpNodeConnection extends NodeConnection {
 
     private final MaxIdleConnections maxIdleConnections;

--- a/core/src/main/java/io/naryo/domain/node/connection/ws/WsNodeConnection.java
+++ b/core/src/main/java/io/naryo/domain/node/connection/ws/WsNodeConnection.java
@@ -5,7 +5,9 @@ import io.naryo.domain.common.connection.endpoint.Protocol;
 import io.naryo.domain.node.connection.NodeConnection;
 import io.naryo.domain.node.connection.NodeConnectionType;
 import io.naryo.domain.node.connection.RetryConfiguration;
+import lombok.experimental.SuperBuilder;
 
+@SuperBuilder(toBuilder = true)
 public final class WsNodeConnection extends NodeConnection {
     public WsNodeConnection(ConnectionEndpoint endpoint, RetryConfiguration retryConfiguration) {
         super(NodeConnectionType.WS, endpoint, retryConfiguration);

--- a/core/src/main/java/io/naryo/domain/node/ethereum/EthereumNode.java
+++ b/core/src/main/java/io/naryo/domain/node/ethereum/EthereumNode.java
@@ -11,10 +11,12 @@ import io.naryo.domain.node.subscription.SubscriptionConfiguration;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
+@SuperBuilder(toBuilder = true)
 public abstract class EthereumNode extends Node {
 
     private final EthereumNodeVisibility visibility;

--- a/core/src/main/java/io/naryo/domain/node/ethereum/priv/PrivateEthereumNode.java
+++ b/core/src/main/java/io/naryo/domain/node/ethereum/priv/PrivateEthereumNode.java
@@ -12,10 +12,12 @@ import io.naryo.domain.node.subscription.SubscriptionConfiguration;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
+@SuperBuilder(toBuilder = true)
 public final class PrivateEthereumNode extends EthereumNode {
 
     private final GroupId groupId;

--- a/core/src/main/java/io/naryo/domain/node/ethereum/pub/PublicEthereumNode.java
+++ b/core/src/main/java/io/naryo/domain/node/ethereum/pub/PublicEthereumNode.java
@@ -8,7 +8,9 @@ import io.naryo.domain.node.ethereum.EthereumNode;
 import io.naryo.domain.node.ethereum.EthereumNodeVisibility;
 import io.naryo.domain.node.interaction.InteractionConfiguration;
 import io.naryo.domain.node.subscription.SubscriptionConfiguration;
+import lombok.experimental.SuperBuilder;
 
+@SuperBuilder(toBuilder = true)
 public final class PublicEthereumNode extends EthereumNode {
     public PublicEthereumNode(
             UUID id,

--- a/core/src/main/java/io/naryo/domain/node/hedera/HederaNode.java
+++ b/core/src/main/java/io/naryo/domain/node/hedera/HederaNode.java
@@ -8,7 +8,9 @@ import io.naryo.domain.node.NodeType;
 import io.naryo.domain.node.connection.NodeConnection;
 import io.naryo.domain.node.interaction.InteractionConfiguration;
 import io.naryo.domain.node.subscription.SubscriptionConfiguration;
+import lombok.experimental.SuperBuilder;
 
+@SuperBuilder(toBuilder = true)
 public final class HederaNode extends Node {
     public HederaNode(
             UUID id,

--- a/core/src/main/java/io/naryo/domain/normalization/Normalizer.java
+++ b/core/src/main/java/io/naryo/domain/normalization/Normalizer.java
@@ -1,0 +1,6 @@
+package io.naryo.domain.normalization;
+
+public interface Normalizer<T> {
+
+    T normalize(T in);
+}

--- a/core/src/test/java/io/naryo/application/broadcaster/configuration/revision/BroadcasterConfigurationRevisionFingerprinterTest.java
+++ b/core/src/test/java/io/naryo/application/broadcaster/configuration/revision/BroadcasterConfigurationRevisionFingerprinterTest.java
@@ -1,0 +1,28 @@
+package io.naryo.application.broadcaster.configuration.revision;
+
+import io.naryo.application.broadcaster.configuration.normalization.BroadcasterConfigurationNormalizerRegistry;
+import io.naryo.application.common.revision.BaseRevisionFingerprinterTest;
+import io.naryo.domain.configuration.broadcaster.BroadcasterConfiguration;
+import io.naryo.domain.configuration.broadcaster.BroadcasterConfigurationNormalizer;
+import io.naryo.domain.configuration.broadcaster.http.HttpBroadcasterConfigurationBuilder;
+import org.junit.jupiter.api.BeforeEach;
+
+class BroadcasterConfigurationRevisionFingerprinterTest
+        extends BaseRevisionFingerprinterTest<BroadcasterConfiguration> {
+
+    protected BroadcasterConfigurationRevisionFingerprinterTest() {
+        super(BroadcasterConfiguration::getId);
+    }
+
+    @BeforeEach
+    void setUp() {
+        var registry = new BroadcasterConfigurationNormalizerRegistry();
+        var normalizer = new BroadcasterConfigurationNormalizer(registry);
+        fingerprinter = new BroadcasterConfigurationRevisionFingerprinter(normalizer);
+    }
+
+    @Override
+    protected BroadcasterConfiguration createInput() {
+        return new HttpBroadcasterConfigurationBuilder().build();
+    }
+}

--- a/core/src/test/java/io/naryo/application/broadcaster/revision/BroadcasterRevisionFingerprinterTest.java
+++ b/core/src/test/java/io/naryo/application/broadcaster/revision/BroadcasterRevisionFingerprinterTest.java
@@ -1,0 +1,23 @@
+package io.naryo.application.broadcaster.revision;
+
+import io.naryo.application.common.revision.BaseRevisionFingerprinterTest;
+import io.naryo.domain.broadcaster.Broadcaster;
+import io.naryo.domain.broadcaster.BroadcasterBuilder;
+import org.junit.jupiter.api.BeforeEach;
+
+class BroadcasterRevisionFingerprinterTest extends BaseRevisionFingerprinterTest<Broadcaster> {
+
+    protected BroadcasterRevisionFingerprinterTest() {
+        super(Broadcaster::getId);
+    }
+
+    @BeforeEach
+    void setUp() {
+        fingerprinter = new BroadcasterRevisionFingerprinter();
+    }
+
+    @Override
+    protected Broadcaster createInput() {
+        return new BroadcasterBuilder().build();
+    }
+}

--- a/core/src/test/java/io/naryo/application/common/revision/BaseRevisionFingerprinterTest.java
+++ b/core/src/test/java/io/naryo/application/common/revision/BaseRevisionFingerprinterTest.java
@@ -1,0 +1,92 @@
+package io.naryo.application.common.revision;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public abstract class BaseRevisionFingerprinterTest<T> {
+
+    protected DefaultRevisionFingerprinter<T> fingerprinter;
+    protected final Function<T, UUID> idFn;
+
+    protected BaseRevisionFingerprinterTest(Function<T, UUID> idFn) {
+        this.idFn = idFn;
+    }
+
+    protected abstract T createInput();
+
+    @Test
+    void itemHash_outputsHex() {
+        var in = createInput();
+
+        String out = fingerprinter.itemHash(in);
+
+        assertNotNull(out);
+        assertTrue(out.matches("(?i)^(0x)?[0-9a-f]{64}$"));
+    }
+
+    @Test
+    void itemHash_withDifferentInputs() {
+        T in = null;
+        T secIn = null;
+        var equals = true;
+
+        while (equals) {
+            in = createInput();
+            secIn = createInput();
+            equals = in.equals(secIn);
+        }
+
+        String out = fingerprinter.itemHash(in);
+        String secOut = fingerprinter.itemHash(secIn);
+
+        assertNotEquals(secOut, out);
+    }
+
+    @Test
+    void itemHash_withSameInputs() {
+        var in = createInput();
+
+        String out = fingerprinter.itemHash(in);
+        String secOut = fingerprinter.itemHash(in);
+
+        assertEquals(out, secOut);
+    }
+
+    @Test
+    void itemHash_withNullInput() {
+        assertThrows(NullPointerException.class, () -> fingerprinter.itemHash(null));
+    }
+
+    @Test
+    void revisionHash_withDifferentInputs() {
+        T in = createInput();
+        T secIn = createInput();
+
+        T bIn = createInput();
+        T bSecIn = createInput();
+
+        String out = fingerprinter.revisionHash(List.of(in, secIn), idFn);
+        String secOut = fingerprinter.revisionHash(List.of(bIn, bSecIn), idFn);
+
+        assertNotEquals(out, secOut);
+    }
+
+    @Test
+    void revisionHash_withSameInputs() {
+        T in = createInput();
+        T secIn = createInput();
+
+        String out = fingerprinter.revisionHash(List.of(in, secIn), idFn);
+        String secOut = fingerprinter.revisionHash(List.of(in, secIn), idFn);
+
+        assertEquals(out, secOut);
+    }
+}

--- a/core/src/test/java/io/naryo/application/filter/revision/FilterRevisionFingerprinterTest.java
+++ b/core/src/test/java/io/naryo/application/filter/revision/FilterRevisionFingerprinterTest.java
@@ -1,0 +1,37 @@
+package io.naryo.application.filter.revision;
+
+import java.util.Random;
+
+import io.naryo.application.common.revision.BaseRevisionFingerprinterTest;
+import io.naryo.domain.filter.Filter;
+import io.naryo.domain.filter.FilterBuilder;
+import io.naryo.domain.filter.event.ContractEventFilterBuilder;
+import io.naryo.domain.filter.event.GlobalEventFilterBuilder;
+import io.naryo.domain.filter.transaction.TransactionFilterBuilder;
+import org.junit.jupiter.api.BeforeEach;
+
+class FilterRevisionFingerprinterTest extends BaseRevisionFingerprinterTest<Filter> {
+
+    protected FilterRevisionFingerprinterTest() {
+        super(Filter::getId);
+    }
+
+    @BeforeEach
+    void setUp() {
+        fingerprinter = new FilterRevisionFingerprinter();
+    }
+
+    @Override
+    protected Filter createInput() {
+        var random = new Random().nextInt(3);
+        FilterBuilder<?, ?> builder =
+                switch (random) {
+                    case 0 -> new ContractEventFilterBuilder();
+                    case 1 -> new GlobalEventFilterBuilder();
+                    case 2 -> new TransactionFilterBuilder();
+                    default -> throw new IllegalStateException("Unexpected value: " + random);
+                };
+
+        return builder.build();
+    }
+}

--- a/core/src/test/java/io/naryo/application/node/revision/NodeRevisionFingerprinterTest.java
+++ b/core/src/test/java/io/naryo/application/node/revision/NodeRevisionFingerprinterTest.java
@@ -1,0 +1,37 @@
+package io.naryo.application.node.revision;
+
+import java.util.Random;
+
+import io.naryo.application.common.revision.BaseRevisionFingerprinterTest;
+import io.naryo.domain.node.Node;
+import io.naryo.domain.node.NodeBuilder;
+import io.naryo.domain.node.eth.priv.PrivateEthereumNodeBuilder;
+import io.naryo.domain.node.eth.pub.PublicEthereumNodeBuilder;
+import io.naryo.domain.node.hedera.HederaNodeBuilder;
+import org.junit.jupiter.api.BeforeEach;
+
+class NodeRevisionFingerprinterTest extends BaseRevisionFingerprinterTest<Node> {
+
+    protected NodeRevisionFingerprinterTest() {
+        super(Node::getId);
+    }
+
+    @BeforeEach
+    void setUp() {
+        fingerprinter = new NodeRevisionFingerprinter();
+    }
+
+    @Override
+    protected Node createInput() {
+        var random = new Random().nextInt(3);
+        NodeBuilder<?, ?> builder =
+                switch (random) {
+                    case 0 -> new PublicEthereumNodeBuilder();
+                    case 1 -> new PrivateEthereumNodeBuilder();
+                    case 2 -> new HederaNodeBuilder();
+                    default -> throw new IllegalStateException("Unexpected value: " + random);
+                };
+
+        return builder.build();
+    }
+}

--- a/core/src/test/java/io/naryo/application/store/revision/StoreRevisionFingerprinterTest.java
+++ b/core/src/test/java/io/naryo/application/store/revision/StoreRevisionFingerprinterTest.java
@@ -1,0 +1,41 @@
+package io.naryo.application.store.revision;
+
+import java.util.Random;
+
+import io.naryo.application.common.revision.BaseRevisionFingerprinterTest;
+import io.naryo.application.store.configuration.normalization.ActiveStoreConfigurationNormalizerRegistry;
+import io.naryo.domain.configuration.store.StoreConfiguration;
+import io.naryo.domain.configuration.store.StoreConfigurationBuilder;
+import io.naryo.domain.configuration.store.StoreConfigurationNormalizer;
+import io.naryo.domain.configuration.store.active.ActiveStoreConfigurationNormalizer;
+import io.naryo.domain.configuration.store.active.HttpStoreConfigurationBuilder;
+import io.naryo.domain.configuration.store.inactive.InactiveStoreConfigurationBuilder;
+import org.junit.jupiter.api.BeforeEach;
+
+class StoreRevisionFingerprinterTest extends BaseRevisionFingerprinterTest<StoreConfiguration> {
+
+    protected StoreRevisionFingerprinterTest() {
+        super(StoreConfiguration::getNodeId);
+    }
+
+    @BeforeEach
+    void setUp() {
+        var registry = new ActiveStoreConfigurationNormalizerRegistry();
+        var activeNormalizer = new ActiveStoreConfigurationNormalizer(registry);
+        var normalizer = new StoreConfigurationNormalizer(activeNormalizer);
+        fingerprinter = new StoreRevisionFingerprinter(normalizer);
+    }
+
+    @Override
+    protected StoreConfiguration createInput() {
+        var random = new Random().nextInt(2);
+        StoreConfigurationBuilder<?, ?> builder =
+                switch (random) {
+                    case 0 -> new InactiveStoreConfigurationBuilder();
+                    case 1 -> new HttpStoreConfigurationBuilder();
+                    default -> throw new IllegalStateException("Unexpected value: " + random);
+                };
+
+        return builder.build();
+    }
+}


### PR DESCRIPTION
### Summary
•  Introduces deterministic “revision fingerprinting” across domain models (Broadcaster, Filter, Node, StoreConfiguration) using normalization + canonical JSON + SHA3 hashing.
•  Adds normalization layer and registries to ensure stable, order-independent fingerprints.

### Key changes
•  New RevisionFingerprinter API and DefaultRevisionFingerprinter with: CanonicalJson utility (ordered keys, JavaTime module, non-null inclusion), itemHash and revisionHash (per-item SHA3 and aggregate, sorted by id)
•  Add jackson-datatype-jsr310 dependency for Java time serialization.
•  New Normalizer interface and implementations
•  Type-based normalizer registries: BroadcasterConfigurationNormalizerRegistry and ActiveStoreConfigurationNormalizerRegistry
•  Domain model updates (to support normalization)
•  Widespread addition of Lombok @Builder/@SuperBuilder(toBuilder = true) across the domain.
•  BaseRevisionFingerprinterTest with suites for Broadcaster, Filter, Node, and StoreConfiguration fingerprinting. Verifies hex output, determinism for identical inputs, and variation for different inputs.