### PR TITLE
doc: RabbitMQ configuration

### DIFF
--- a/docs/broadcasting/configuration-kafka.md
+++ b/docs/broadcasting/configuration-kafka.md
@@ -57,7 +57,7 @@ References to configuring a Broadcaster
 
 1. [Getting Started](../getting_started.md)
 2. [Naryo Configuration](./index.md)
-3. [Core Configuration Overview](./configuration-core.md)
+3. [Core Configuration Overview](../configuration/configuration-core.md)
 
 ## 👉 Next steps
 

--- a/docs/broadcasting/configuration-rabbit.md
+++ b/docs/broadcasting/configuration-rabbit.md
@@ -1,0 +1,64 @@
+# 📚 Rabbit Configuration Overview
+
+This document describes how to configure **Naryo** using **Rabbit** as a broadcaster.
+
+---
+
+## Table of Contents
+
+- [Broadcaster Spring Rabbit Configuration](#broadcaster-spring-rabbit-configuration)
+- [Broadcasting Configuration](#broadcaster-configuration)
+
+---
+
+## Broadcaster Spring Rabbit Configuration
+
+To use a Rabbit broker as a broadcaster in a Naryo server, first add the required dependencies to your build,
+then configure the Rabbit connection.
+
+### 1) Add the module
+
+Add the dependency to your `build.gradle` file with desired version:
+
+```groovy
+dependencies {
+    implementation 'io.naryo:broadcaster-spring-rabbit:<version>'
+}
+```
+
+### 2) Configure Spring to connect to Rabbit
+
+Add the following to your application.yaml:
+
+```yaml
+spring:
+  rabbitmq:
+    host: {host} # e.g. localhost
+    port: {port} # e.g. 5672
+    username: {username} # e.g. guest
+    password: {password} # e.g. guest
+```
+---
+
+## Broadcaster Configuration
+
+To use Rabbit as a broadcaster, a Broadcaster Configuration shall be configured with `type=rabbitmq`.
+
+To define the exchange and routing key to be used, make use of the configured Broadcaster's `target` property.
+
+References to configuring a Broadcaster
+[yaml](../configuration/configuration-core.md#-2-broadcasting-configuration),
+[jpa](../configuration/configuration-jpa.md#-broadcasting-configuration) or
+[mongo](../configuration/configuration-mongo.md#-broadcasting-configuration)) ).
+
+---
+
+## 👈 Previous steps
+
+1. [Getting Started](../getting_started.md)
+2. [Naryo Configuration](./index.md)
+3. [Core Configuration Overview](../configuration/configuration-core.md)
+
+## 👉 Next steps
+
+1. [Tutorials](../tutorials/index.md)

--- a/docs/broadcasting/index.md
+++ b/docs/broadcasting/index.md
@@ -1,0 +1,39 @@
+# 🎉 Naryo Broadcasting
+
+Naryo supports multiple broadcasting mechanisms to distribute events and messages across your system. This document provides an overview of the available broadcasting options and how to configure them.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Kafka Broadcasting](#kafka-broadcasting)
+- [RabbitMQ Broadcasting](#rabbitmq-broadcasting)
+- [HTTP Broadcasting](#http-broadcasting)
+
+## Overview
+
+Broadcasting in Naryo allows you to publish events and messages to various destinations.
+Each broadcasting option has its own strengths and use cases. Naryo currently supports the following broadcasting mechanisms:
+
+1. **Kafka**
+2. **RabbitMQ**
+3. **HTTP**
+
+## Kafka Broadcasting
+
+Detailed Kafka configuration can be found at [Kafka Configuration](./configuration-kafka.md) guide.
+
+## RabbitMQ Broadcasting
+
+Detailed RabbitMQ configuration can be found at [RabbitMQ Configuration](./configuration-rabbit.md) guide.
+
+## HTTP Broadcasting
+
+HTTP broadcasting configuration is not yet documented. Please refer to the project's source code or contact the development team for more information.
+
+## 👈 Previous steps
+
+1. [Configuration](../configuration/index.md)
+
+## 👉 Next steps
+
+1. [Tutorials](../tutorials/index.md)

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -4,6 +4,7 @@
   - [How is priority handled?](#how-is-priority-handled)
 - [Core Configuration Overview](#-core-configuration-overview)
 - [MongoDB Configuration Overview](#-mongo-configuration-overview)
+- [JPA Configuration Overview](#-jpa-configuration-overview)
 
 Naryo supports flexible configuration mechanisms. The core module requires manual configuration through custom
 implementation due to its framework-agnostic design and wide configuration domain. Configuration can be loaded from
@@ -21,6 +22,9 @@ Currently, two configuration sources are supported:
 - **MongoDB**
   - The **`persistence-spring-mongo`** module enables dynamic configuration loading from MongoDB, based on each domain's model.
 
+- **JPA**
+    - The **`persistence-spring-jpa`** module enables dynamic configuration loading from PostgreSQL, based on each domain's model.
+
 ### How is priority handled?
 In order to manage configurations flexibly, Naryo implements a priority system among configuration sources. Priority is defined as follows:
 
@@ -34,6 +38,10 @@ In order to manage configurations flexibly, Naryo implements a priority system a
 ## 📚 Mongo Configuration Overview
 
 [Mongo Configuration Overview](./configuration-mongo.md)
+
+## 📚 JPA Configuration Overview
+
+[JPA Configuration Overview](./configuration-jpa.md)
 
 ## 👈 Previous steps
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -188,4 +188,5 @@ Need help setting it up in your use case? Let us know or check out the [tutorial
 ## 👉 Next Steps
 
 1. [Configuration Documentation](./configuration/index.md)
-2. [Tutorials](./tutorials/index.md)
+2. [Broadcasting Documentation](./broadcasting/index.md)
+3. [Tutorials](./tutorials/index.md)


### PR DESCRIPTION
This PR introduces the RabbitMQ basic configuration documentation and refactors the structure of the documentation to introduce Broadcasting docs.