### PR TITLE
chore: Configuration revision manager implementation

### DIFF
--- a/core/src/main/java/io/naryo/application/broadcaster/configuration/revision/BroadcasterConfigurationConfigurationRevisionManager.java
+++ b/core/src/main/java/io/naryo/application/broadcaster/configuration/revision/BroadcasterConfigurationConfigurationRevisionManager.java
@@ -1,0 +1,17 @@
+package io.naryo.application.broadcaster.configuration.revision;
+
+import io.naryo.application.broadcaster.configuration.manager.BroadcasterConfigurationConfigurationManager;
+import io.naryo.application.configuration.revision.manager.DefaultConfigurationRevisionManager;
+import io.naryo.application.configuration.revision.registry.LiveRegistry;
+import io.naryo.domain.configuration.broadcaster.BroadcasterConfiguration;
+
+public final class BroadcasterConfigurationConfigurationRevisionManager
+        extends DefaultConfigurationRevisionManager<BroadcasterConfiguration> {
+
+    public BroadcasterConfigurationConfigurationRevisionManager(
+            BroadcasterConfigurationConfigurationManager configurationManager,
+            BroadcasterConfigurationRevisionFingerprinter fingerprinter,
+            LiveRegistry<BroadcasterConfiguration> live) {
+        super(configurationManager, fingerprinter, BroadcasterConfiguration::getId, live);
+    }
+}

--- a/core/src/main/java/io/naryo/application/broadcaster/configuration/revision/BroadcasterConfigurationRevisionFingerprinter.java
+++ b/core/src/main/java/io/naryo/application/broadcaster/configuration/revision/BroadcasterConfigurationRevisionFingerprinter.java
@@ -1,6 +1,6 @@
 package io.naryo.application.broadcaster.configuration.revision;
 
-import io.naryo.application.common.revision.DefaultRevisionFingerprinter;
+import io.naryo.application.configuration.revision.fingerprint.DefaultRevisionFingerprinter;
 import io.naryo.domain.configuration.broadcaster.BroadcasterConfiguration;
 import io.naryo.domain.configuration.broadcaster.BroadcasterConfigurationNormalizer;
 

--- a/core/src/main/java/io/naryo/application/broadcaster/revision/BroadcasterConfigurationRevisionManager.java
+++ b/core/src/main/java/io/naryo/application/broadcaster/revision/BroadcasterConfigurationRevisionManager.java
@@ -1,0 +1,17 @@
+package io.naryo.application.broadcaster.revision;
+
+import io.naryo.application.broadcaster.configuration.manager.BroadcasterConfigurationManager;
+import io.naryo.application.configuration.revision.manager.DefaultConfigurationRevisionManager;
+import io.naryo.application.configuration.revision.registry.LiveRegistry;
+import io.naryo.domain.broadcaster.Broadcaster;
+
+public final class BroadcasterConfigurationRevisionManager
+        extends DefaultConfigurationRevisionManager<Broadcaster> {
+
+    public BroadcasterConfigurationRevisionManager(
+            BroadcasterConfigurationManager configurationManager,
+            BroadcasterRevisionFingerprinter fingerprinter,
+            LiveRegistry<Broadcaster> live) {
+        super(configurationManager, fingerprinter, Broadcaster::getId, live);
+    }
+}

--- a/core/src/main/java/io/naryo/application/broadcaster/revision/BroadcasterRevisionFingerprinter.java
+++ b/core/src/main/java/io/naryo/application/broadcaster/revision/BroadcasterRevisionFingerprinter.java
@@ -1,6 +1,6 @@
 package io.naryo.application.broadcaster.revision;
 
-import io.naryo.application.common.revision.DefaultRevisionFingerprinter;
+import io.naryo.application.configuration.revision.fingerprint.DefaultRevisionFingerprinter;
 import io.naryo.domain.broadcaster.Broadcaster;
 import io.naryo.domain.broadcaster.BroadcasterNormalizer;
 

--- a/core/src/main/java/io/naryo/application/configuration/revision/LiveView.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/LiveView.java
@@ -1,12 +1,7 @@
 package io.naryo.application.configuration.revision;
 
 import java.util.Map;
+import java.util.UUID;
 
-public interface LiveView<T> {
-
-    Revision<T> revision();
-
-    Map<String, T> byId();
-
-    Map<String, String> itemFingerprintById();
-}
+public record LiveView<T>(
+        Revision<T> revision, Map<UUID, T> byId, Map<UUID, String> itemFingerprintById) {}

--- a/core/src/main/java/io/naryo/application/configuration/revision/Revision.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/Revision.java
@@ -1,15 +1,16 @@
 package io.naryo.application.configuration.revision;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
-public record Revision<T>(long revision, String hash, List<T> domainItems) {
+public record Revision<T>(long version, String hash, Collection<T> domainItems) {
 
     public Revision {
         Objects.requireNonNull(domainItems, "Items cannot be null");
         Objects.requireNonNull(hash, "Revision hash cannot be null");
         domainItems = List.copyOf(domainItems);
-        if (revision < 0) {
+        if (version < 0) {
             throw new IllegalArgumentException("Number cannot be negative");
         }
         if (hash.isBlank()) {

--- a/core/src/main/java/io/naryo/application/configuration/revision/RevisionConflictException.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/RevisionConflictException.java
@@ -1,0 +1,19 @@
+package io.naryo.application.configuration.revision;
+
+import java.util.UUID;
+
+import io.naryo.application.configuration.revision.operation.RevisionOperationKind;
+import lombok.Getter;
+
+@Getter
+public final class RevisionConflictException extends RuntimeException {
+
+    private final UUID id;
+    private final RevisionOperationKind operationKind;
+
+    public RevisionConflictException(UUID id, RevisionOperationKind operationKind, String message) {
+        super(message);
+        this.id = id;
+        this.operationKind = operationKind;
+    }
+}

--- a/core/src/main/java/io/naryo/application/configuration/revision/diff/DiffResult.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/diff/DiffResult.java
@@ -1,0 +1,7 @@
+package io.naryo.application.configuration.revision.diff;
+
+import java.util.List;
+
+public record DiffResult<T>(List<T> added, List<T> removed, List<Modified<T>> modified) {
+    public record Modified<T>(T before, T after) {}
+}

--- a/core/src/main/java/io/naryo/application/configuration/revision/diff/Diffs.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/diff/Diffs.java
@@ -1,0 +1,43 @@
+package io.naryo.application.configuration.revision.diff;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public final class Diffs {
+
+    private Diffs() {}
+
+    public static <T, K> DiffResult<T> diff(
+            Collection<T> before,
+            Collection<T> after,
+            Function<T, K> idFn,
+            BiPredicate<T, T> semanticallyEqual) {
+
+        var oldMap = before.stream().collect(Collectors.toMap(idFn, Function.identity()));
+        var newMap = after.stream().collect(Collectors.toMap(idFn, Function.identity()));
+
+        var added = new ArrayList<T>();
+        var removed = new ArrayList<T>();
+        var modified = new ArrayList<DiffResult.Modified<T>>();
+
+        for (var e : newMap.entrySet()) {
+            var k = e.getKey();
+            var newItem = e.getValue();
+            var oldItem = oldMap.get(k);
+            if (oldItem == null) {
+                added.add(newItem);
+            } else if (!semanticallyEqual.test(oldItem, newItem)) {
+                modified.add(new DiffResult.Modified<>(oldItem, newItem));
+            }
+        }
+
+        for (var k : oldMap.keySet()) {
+            if (!newMap.containsKey(k)) removed.add(oldMap.get(k));
+        }
+        return new DiffResult<>(List.copyOf(added), List.copyOf(removed), List.copyOf(modified));
+    }
+}

--- a/core/src/main/java/io/naryo/application/configuration/revision/fingerprint/CanonicalJson.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/fingerprint/CanonicalJson.java
@@ -1,4 +1,4 @@
-package io.naryo.application.common.revision;
+package io.naryo.application.configuration.revision.fingerprint;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/core/src/main/java/io/naryo/application/configuration/revision/fingerprint/DefaultRevisionFingerprinter.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/fingerprint/DefaultRevisionFingerprinter.java
@@ -1,4 +1,4 @@
-package io.naryo.application.common.revision;
+package io.naryo.application.configuration.revision.fingerprint;
 
 import java.util.Comparator;
 import java.util.List;

--- a/core/src/main/java/io/naryo/application/configuration/revision/fingerprint/DefaultRevisionFingerprinter.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/fingerprint/DefaultRevisionFingerprinter.java
@@ -1,9 +1,6 @@
 package io.naryo.application.configuration.revision.fingerprint;
 
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -27,7 +24,7 @@ public abstract class DefaultRevisionFingerprinter<T> implements RevisionFingerp
     }
 
     @Override
-    public String revisionHash(List<T> items, Function<T, UUID> idFn) {
+    public String revisionHash(Collection<T> items, Function<T, UUID> idFn) {
         Objects.requireNonNull(items, "items cannot be null");
         Objects.requireNonNull(idFn, "idFn cannot be null");
 

--- a/core/src/main/java/io/naryo/application/configuration/revision/fingerprint/RevisionFingerprinter.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/fingerprint/RevisionFingerprinter.java
@@ -1,4 +1,4 @@
-package io.naryo.application.common.revision;
+package io.naryo.application.configuration.revision.fingerprint;
 
 import java.util.List;
 import java.util.UUID;

--- a/core/src/main/java/io/naryo/application/configuration/revision/fingerprint/RevisionFingerprinter.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/fingerprint/RevisionFingerprinter.java
@@ -1,6 +1,6 @@
 package io.naryo.application.configuration.revision.fingerprint;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.UUID;
 import java.util.function.Function;
 
@@ -8,5 +8,5 @@ public interface RevisionFingerprinter<T> {
 
     String itemHash(T item);
 
-    String revisionHash(List<T> items, Function<T, UUID> idFn);
+    String revisionHash(Collection<T> items, Function<T, UUID> idFn);
 }

--- a/core/src/main/java/io/naryo/application/configuration/revision/hook/RevisionHook.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/hook/RevisionHook.java
@@ -1,0 +1,13 @@
+package io.naryo.application.configuration.revision.hook;
+
+import java.util.List;
+
+import io.naryo.application.configuration.revision.Revision;
+import io.naryo.application.configuration.revision.diff.DiffResult;
+
+public interface RevisionHook<T> {
+
+    default void onBeforeApply(List<T> oldDomain, List<T> newDomain) throws Exception {}
+
+    default void onAfterApply(Revision<T> applied, DiffResult<T> diff) throws Exception {}
+}

--- a/core/src/main/java/io/naryo/application/configuration/revision/hook/RevisionHook.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/hook/RevisionHook.java
@@ -1,13 +1,13 @@
 package io.naryo.application.configuration.revision.hook;
 
-import java.util.List;
+import java.util.Collection;
 
 import io.naryo.application.configuration.revision.Revision;
 import io.naryo.application.configuration.revision.diff.DiffResult;
 
 public interface RevisionHook<T> {
 
-    default void onBeforeApply(List<T> oldDomain, List<T> newDomain) throws Exception {}
+    default void onBeforeApply(Collection<T> oldDomain, Collection<T> newDomain) throws Exception {}
 
     default void onAfterApply(Revision<T> applied, DiffResult<T> diff) throws Exception {}
 }

--- a/core/src/main/java/io/naryo/application/configuration/revision/manager/ConfigurationRevisionManager.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/manager/ConfigurationRevisionManager.java
@@ -1,0 +1,17 @@
+package io.naryo.application.configuration.revision.manager;
+
+import io.naryo.application.configuration.revision.LiveView;
+import io.naryo.application.configuration.revision.Revision;
+import io.naryo.application.configuration.revision.hook.RevisionHook;
+import io.naryo.application.configuration.revision.operation.RevisionOperation;
+
+public interface ConfigurationRevisionManager<T> {
+
+    Revision<T> initialize() throws Exception;
+
+    Revision<T> apply(RevisionOperation<T> op) throws Exception;
+
+    void registerHook(RevisionHook<T> hook);
+
+    LiveView<T> liveView();
+}

--- a/core/src/main/java/io/naryo/application/configuration/revision/manager/DefaultConfigurationRevisionManager.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/manager/DefaultConfigurationRevisionManager.java
@@ -1,0 +1,207 @@
+package io.naryo.application.configuration.revision.manager;
+
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import io.naryo.application.configuration.manager.CollectionConfigurationManager;
+import io.naryo.application.configuration.revision.LiveView;
+import io.naryo.application.configuration.revision.Revision;
+import io.naryo.application.configuration.revision.RevisionConflictException;
+import io.naryo.application.configuration.revision.diff.Diffs;
+import io.naryo.application.configuration.revision.fingerprint.RevisionFingerprinter;
+import io.naryo.application.configuration.revision.hook.RevisionHook;
+import io.naryo.application.configuration.revision.operation.AddOperation;
+import io.naryo.application.configuration.revision.operation.RemoveOperation;
+import io.naryo.application.configuration.revision.operation.RevisionOperation;
+import io.naryo.application.configuration.revision.operation.UpdateOperation;
+import io.naryo.application.configuration.revision.registry.LiveRegistry;
+
+public abstract class DefaultConfigurationRevisionManager<T>
+        implements ConfigurationRevisionManager<T> {
+
+    protected final AtomicLong revisionVersion = new AtomicLong(0);
+    protected final List<RevisionHook<T>> hooks = new CopyOnWriteArrayList<>();
+    protected final CollectionConfigurationManager<T> configurationManager;
+    protected final RevisionFingerprinter<T> fingerprinter;
+    protected final Function<T, UUID> idFn;
+    protected final LiveRegistry<T> live;
+    protected volatile LiveView<T> view;
+
+    protected DefaultConfigurationRevisionManager(
+            CollectionConfigurationManager<T> configurationManager,
+            RevisionFingerprinter<T> fingerprinter,
+            Function<T, UUID> idFn,
+            LiveRegistry<T> live) {
+        this.configurationManager = configurationManager;
+        this.fingerprinter = fingerprinter;
+        this.live = live;
+        this.idFn = idFn;
+    }
+
+    @Override
+    public Revision<T> initialize() throws Exception {
+        Collection<T> conf = configurationManager.load();
+        if (conf == null) conf = List.of();
+        String hash = fingerprinter.revisionHash(conf, idFn);
+
+        var revision = new Revision<>(revisionVersion.get(), hash, conf);
+        view =
+                new LiveView<>(
+                        revision,
+                        conf.stream().collect(Collectors.toMap(idFn, t -> t)),
+                        conf.stream().collect(Collectors.toMap(idFn, fingerprinter::itemHash)));
+
+        live.refresh(revision);
+        return revision;
+    }
+
+    @Override
+    public Revision<T> apply(RevisionOperation<T> op) throws Exception {
+        var curView = view;
+        var current = curView == null ? List.<T>of() : curView.revision().domainItems();
+        var byId = curView == null ? Map.<UUID, T>of() : curView.byId();
+        var itemH = curView == null ? Map.<UUID, String>of() : curView.itemFingerprintById();
+
+        Collection<T> newDomain =
+                switch (op.kind()) {
+                    case ADD -> applyAdd(current, byId, itemH, (AddOperation<T>) op);
+                    case UPDATE -> applyUpdate(current, byId, itemH, (UpdateOperation<T>) op);
+                    case REMOVE -> applyRemove(current, byId, itemH, (RemoveOperation<T>) op);
+                };
+
+        var newHash = fingerprinter.revisionHash(newDomain, idFn);
+        if (curView != null && curView.revision().hash().equals(newHash)) {
+            return curView.revision();
+        }
+
+        Map<UUID, String> newItemH =
+                newDomain.stream().collect(Collectors.toMap(idFn, fingerprinter::itemHash));
+        var diff =
+                Diffs.diff(
+                        current,
+                        newDomain,
+                        idFn,
+                        (a, b) ->
+                                Objects.equals(
+                                        itemH.get(idFn.apply(a)), newItemH.get(idFn.apply(b))));
+
+        for (var h : hooks) {
+            try {
+                h.onBeforeApply(current, newDomain);
+            } catch (Exception e) {
+                throw new RuntimeException("onBeforeApply hook error", e);
+            }
+        }
+
+        var applied = publish(newDomain);
+
+        for (var h : hooks) {
+            try {
+                h.onAfterApply(applied, diff);
+            } catch (Exception e) {
+                throw new RuntimeException("onAfterApply hook error", e);
+            }
+        }
+
+        return applied;
+    }
+
+    @Override
+    public void registerHook(RevisionHook<T> hook) {
+        if (hook == null) return;
+        hooks.add(hook);
+    }
+
+    @Override
+    public LiveView<T> liveView() {
+        return view;
+    }
+
+    private Revision<T> publish(Collection<T> canonical) {
+        var hash = fingerprinter.revisionHash(canonical, idFn);
+        var rev = new Revision<>(revisionVersion.incrementAndGet(), hash, List.copyOf(canonical));
+        int cap = Math.max(16, (int) (canonical.size() / 0.75f) + 1);
+        Map<UUID, T> byId = new HashMap<>(cap);
+        Map<UUID, String> itemH = new HashMap<>(cap);
+        for (T t : canonical) {
+            UUID id = idFn.apply(t);
+            byId.put(id, t);
+            itemH.put(id, fingerprinter.itemHash(t));
+        }
+
+        this.view = new LiveView<>(rev, byId, itemH);
+        live.refresh(rev);
+        return rev;
+    }
+
+    private Collection<T> applyAdd(
+            Collection<T> current, Map<UUID, T> byId, Map<UUID, String> itemH, AddOperation<T> op) {
+        var id = idFn.apply(op.item());
+        var cur = byId.get(id);
+        if (cur == null) {
+            var out = new ArrayList<>(current);
+            out.add(op.item());
+            return List.copyOf(out);
+        }
+
+        if (Objects.equals(itemH.get(id), fingerprinter.itemHash(op.item()))) return current;
+        throw new RevisionConflictException(
+                id,
+                op.kind(),
+                "Item exists with different contents (expectedHash="
+                        + itemH.get(id)
+                        + ", newHash="
+                        + fingerprinter.itemHash(op.item())
+                        + ")");
+    }
+
+    private Collection<T> applyUpdate(
+            Collection<T> current,
+            Map<UUID, T> byId,
+            Map<UUID, String> itemH,
+            UpdateOperation<T> op) {
+        var cur = byId.get(op.id());
+        if (cur == null) throw new RevisionConflictException(op.id(), op.kind(), "Item not found");
+        var actualHash = itemH.get(op.id());
+        if (!Objects.equals(actualHash, op.prevItemHash()))
+            throw new RevisionConflictException(
+                    op.id(),
+                    op.kind(),
+                    "Item changed since base (expectedPrevHash="
+                            + op.prevItemHash()
+                            + ", actualPrevHash="
+                            + actualHash
+                            + ")");
+        var out = new ArrayList<>(current);
+        for (int i = 0; i < out.size(); i++) {
+            if (Objects.equals(idFn.apply(out.get(i)), op.id())) {
+                out.set(i, op.proposed());
+                return List.copyOf(out);
+            }
+        }
+        throw new RevisionConflictException(op.id(), op.kind(), "Item not found during update");
+    }
+
+    private Collection<T> applyRemove(
+            Collection<T> current,
+            Map<UUID, T> byId,
+            Map<UUID, String> itemH,
+            RemoveOperation<T> op) {
+        var cur = byId.get(op.id());
+        if (cur == null) return current;
+        var actualHash = itemH.get(op.id());
+        if (!Objects.equals(actualHash, op.prevItemHash()))
+            throw new RevisionConflictException(
+                    op.id(),
+                    op.kind(),
+                    "Item changed since base (expectedPrevHash="
+                            + op.prevItemHash()
+                            + ", actualPrevHash="
+                            + actualHash
+                            + ")");
+        return current.stream().filter(t -> !Objects.equals(idFn.apply(t), op.id())).toList();
+    }
+}

--- a/core/src/main/java/io/naryo/application/configuration/revision/operation/AddOperation.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/operation/AddOperation.java
@@ -1,0 +1,8 @@
+package io.naryo.application.configuration.revision.operation;
+
+public record AddOperation<T>(T item) implements RevisionOperation<T> {
+    @Override
+    public RevisionOperationKind kind() {
+        return RevisionOperationKind.ADD;
+    }
+}

--- a/core/src/main/java/io/naryo/application/configuration/revision/operation/RemoveOperation.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/operation/RemoveOperation.java
@@ -1,0 +1,8 @@
+package io.naryo.application.configuration.revision.operation;
+
+public record RemoveOperation<T>(String id, String prevItemHash) implements RevisionOperation<T> {
+    @Override
+    public RevisionOperationKind kind() {
+        return RevisionOperationKind.REMOVE;
+    }
+}

--- a/core/src/main/java/io/naryo/application/configuration/revision/operation/RemoveOperation.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/operation/RemoveOperation.java
@@ -1,6 +1,8 @@
 package io.naryo.application.configuration.revision.operation;
 
-public record RemoveOperation<T>(String id, String prevItemHash) implements RevisionOperation<T> {
+import java.util.UUID;
+
+public record RemoveOperation<T>(UUID id, String prevItemHash) implements RevisionOperation<T> {
     @Override
     public RevisionOperationKind kind() {
         return RevisionOperationKind.REMOVE;

--- a/core/src/main/java/io/naryo/application/configuration/revision/operation/RevisionOperation.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/operation/RevisionOperation.java
@@ -1,0 +1,6 @@
+package io.naryo.application.configuration.revision.operation;
+
+public sealed interface RevisionOperation<T>
+        permits AddOperation, UpdateOperation, RemoveOperation {
+    RevisionOperationKind kind();
+}

--- a/core/src/main/java/io/naryo/application/configuration/revision/operation/RevisionOperationKind.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/operation/RevisionOperationKind.java
@@ -1,0 +1,7 @@
+package io.naryo.application.configuration.revision.operation;
+
+public enum RevisionOperationKind {
+    ADD,
+    UPDATE,
+    REMOVE
+}

--- a/core/src/main/java/io/naryo/application/configuration/revision/operation/UpdateOperation.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/operation/UpdateOperation.java
@@ -1,6 +1,8 @@
 package io.naryo.application.configuration.revision.operation;
 
-public record UpdateOperation<T>(String id, String prevItemHash, T proposed)
+import java.util.UUID;
+
+public record UpdateOperation<T>(UUID id, String prevItemHash, T proposed)
         implements RevisionOperation<T> {
     @Override
     public RevisionOperationKind kind() {

--- a/core/src/main/java/io/naryo/application/configuration/revision/operation/UpdateOperation.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/operation/UpdateOperation.java
@@ -1,0 +1,9 @@
+package io.naryo.application.configuration.revision.operation;
+
+public record UpdateOperation<T>(String id, String prevItemHash, T proposed)
+        implements RevisionOperation<T> {
+    @Override
+    public RevisionOperationKind kind() {
+        return RevisionOperationKind.UPDATE;
+    }
+}

--- a/core/src/main/java/io/naryo/application/configuration/revision/registry/DefaultLiveRegistries.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/registry/DefaultLiveRegistries.java
@@ -1,10 +1,8 @@
-package io.naryo.application.configuration.revision.impl;
+package io.naryo.application.configuration.revision.registry;
 
 import java.util.Map;
 import java.util.Objects;
 
-import io.naryo.application.configuration.revision.LiveRegistries;
-import io.naryo.application.configuration.revision.LiveRegistry;
 import io.naryo.domain.broadcaster.Broadcaster;
 import io.naryo.domain.common.http.HttpClient;
 import io.naryo.domain.configuration.broadcaster.BroadcasterConfiguration;

--- a/core/src/main/java/io/naryo/application/configuration/revision/registry/DefaultLiveRegistry.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/registry/DefaultLiveRegistry.java
@@ -1,9 +1,8 @@
-package io.naryo.application.configuration.revision.impl;
+package io.naryo.application.configuration.revision.registry;
 
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.naryo.application.configuration.revision.LiveRegistry;
 import io.naryo.application.configuration.revision.Revision;
 
 public class DefaultLiveRegistry<T> implements LiveRegistry<T> {

--- a/core/src/main/java/io/naryo/application/configuration/revision/registry/LiveRegistries.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/registry/LiveRegistries.java
@@ -1,4 +1,4 @@
-package io.naryo.application.configuration.revision;
+package io.naryo.application.configuration.revision.registry;
 
 import io.naryo.domain.broadcaster.Broadcaster;
 import io.naryo.domain.common.http.HttpClient;

--- a/core/src/main/java/io/naryo/application/configuration/revision/registry/LiveRegistry.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/registry/LiveRegistry.java
@@ -1,4 +1,6 @@
-package io.naryo.application.configuration.revision;
+package io.naryo.application.configuration.revision.registry;
+
+import io.naryo.application.configuration.revision.Revision;
 
 public interface LiveRegistry<T> {
 

--- a/core/src/main/java/io/naryo/application/filter/revision/FilterConfigurationRevisionManager.java
+++ b/core/src/main/java/io/naryo/application/filter/revision/FilterConfigurationRevisionManager.java
@@ -1,0 +1,17 @@
+package io.naryo.application.filter.revision;
+
+import io.naryo.application.configuration.revision.manager.DefaultConfigurationRevisionManager;
+import io.naryo.application.configuration.revision.registry.LiveRegistry;
+import io.naryo.application.filter.configuration.manager.FilterConfigurationManager;
+import io.naryo.domain.filter.Filter;
+
+public final class FilterConfigurationRevisionManager
+        extends DefaultConfigurationRevisionManager<Filter> {
+
+    public FilterConfigurationRevisionManager(
+            FilterConfigurationManager configurationManager,
+            FilterRevisionFingerprinter fingerprinter,
+            LiveRegistry<Filter> live) {
+        super(configurationManager, fingerprinter, Filter::getId, live);
+    }
+}

--- a/core/src/main/java/io/naryo/application/filter/revision/FilterRevisionFingerprinter.java
+++ b/core/src/main/java/io/naryo/application/filter/revision/FilterRevisionFingerprinter.java
@@ -1,6 +1,6 @@
 package io.naryo.application.filter.revision;
 
-import io.naryo.application.common.revision.DefaultRevisionFingerprinter;
+import io.naryo.application.configuration.revision.fingerprint.DefaultRevisionFingerprinter;
 import io.naryo.domain.filter.Filter;
 import io.naryo.domain.filter.FilterNormalizer;
 

--- a/core/src/main/java/io/naryo/application/node/revision/NodeConfigurationRevisionManager.java
+++ b/core/src/main/java/io/naryo/application/node/revision/NodeConfigurationRevisionManager.java
@@ -1,0 +1,17 @@
+package io.naryo.application.node.revision;
+
+import io.naryo.application.configuration.revision.manager.DefaultConfigurationRevisionManager;
+import io.naryo.application.configuration.revision.registry.LiveRegistry;
+import io.naryo.application.node.configuration.manager.NodeConfigurationManager;
+import io.naryo.domain.node.Node;
+
+public final class NodeConfigurationRevisionManager
+        extends DefaultConfigurationRevisionManager<Node> {
+
+    public NodeConfigurationRevisionManager(
+            NodeConfigurationManager configurationManager,
+            NodeRevisionFingerprinter fingerprinter,
+            LiveRegistry<Node> live) {
+        super(configurationManager, fingerprinter, Node::getId, live);
+    }
+}

--- a/core/src/main/java/io/naryo/application/node/revision/NodeRevisionFingerprinter.java
+++ b/core/src/main/java/io/naryo/application/node/revision/NodeRevisionFingerprinter.java
@@ -1,6 +1,6 @@
 package io.naryo.application.node.revision;
 
-import io.naryo.application.common.revision.DefaultRevisionFingerprinter;
+import io.naryo.application.configuration.revision.fingerprint.DefaultRevisionFingerprinter;
 import io.naryo.domain.node.Node;
 import io.naryo.domain.node.NodeNormalizer;
 

--- a/core/src/main/java/io/naryo/application/store/revision/StoreConfigurationRevisionManager.java
+++ b/core/src/main/java/io/naryo/application/store/revision/StoreConfigurationRevisionManager.java
@@ -1,0 +1,17 @@
+package io.naryo.application.store.revision;
+
+import io.naryo.application.configuration.revision.manager.DefaultConfigurationRevisionManager;
+import io.naryo.application.configuration.revision.registry.LiveRegistry;
+import io.naryo.application.store.configuration.manager.StoreConfigurationManager;
+import io.naryo.domain.configuration.store.StoreConfiguration;
+
+public final class StoreConfigurationRevisionManager
+        extends DefaultConfigurationRevisionManager<StoreConfiguration> {
+
+    public StoreConfigurationRevisionManager(
+            StoreConfigurationManager configurationManager,
+            StoreRevisionFingerprinter fingerprinter,
+            LiveRegistry<StoreConfiguration> live) {
+        super(configurationManager, fingerprinter, StoreConfiguration::getNodeId, live);
+    }
+}

--- a/core/src/main/java/io/naryo/application/store/revision/StoreRevisionFingerprinter.java
+++ b/core/src/main/java/io/naryo/application/store/revision/StoreRevisionFingerprinter.java
@@ -1,6 +1,6 @@
 package io.naryo.application.store.revision;
 
-import io.naryo.application.common.revision.DefaultRevisionFingerprinter;
+import io.naryo.application.configuration.revision.fingerprint.DefaultRevisionFingerprinter;
 import io.naryo.domain.configuration.store.StoreConfiguration;
 import io.naryo.domain.configuration.store.StoreConfigurationNormalizer;
 

--- a/core/src/main/java/io/naryo/domain/broadcaster/Broadcaster.java
+++ b/core/src/main/java/io/naryo/domain/broadcaster/Broadcaster.java
@@ -15,7 +15,7 @@ public class Broadcaster {
     private UUID configurationId;
 
     public Broadcaster(UUID id, BroadcasterTarget target, UUID configurationId) {
-        Objects.requireNonNull(id, "filterId cannot be null");
+        Objects.requireNonNull(id, "id cannot be null");
         Objects.requireNonNull(target, "target cannot be null");
         Objects.requireNonNull(configurationId, "configurationId cannot be null");
 

--- a/core/src/test/java/io/naryo/application/broadcaster/configuration/revision/BroadcasterConfigurationConfigurationRevisionManagerTest.java
+++ b/core/src/test/java/io/naryo/application/broadcaster/configuration/revision/BroadcasterConfigurationConfigurationRevisionManagerTest.java
@@ -1,0 +1,47 @@
+package io.naryo.application.broadcaster.configuration.revision;
+
+import io.naryo.application.broadcaster.configuration.manager.BroadcasterConfigurationConfigurationManager;
+import io.naryo.application.broadcaster.configuration.normalization.BroadcasterConfigurationNormalizerRegistry;
+import io.naryo.application.configuration.revision.manager.BaseConfigurationRevisionManagerTest;
+import io.naryo.application.configuration.revision.manager.ConfigurationRevisionManager;
+import io.naryo.application.configuration.revision.registry.LiveRegistry;
+import io.naryo.domain.configuration.broadcaster.BroadcasterConfiguration;
+import io.naryo.domain.configuration.broadcaster.BroadcasterConfigurationNormalizer;
+import io.naryo.domain.configuration.broadcaster.http.HttpBroadcasterConfigurationBuilder;
+
+class BroadcasterConfigurationConfigurationRevisionManagerTest
+        extends BaseConfigurationRevisionManagerTest<
+                BroadcasterConfiguration,
+                BroadcasterConfigurationConfigurationManager,
+                BroadcasterConfigurationRevisionFingerprinter> {
+
+    protected BroadcasterConfigurationConfigurationRevisionManagerTest() {
+        super(BroadcasterConfiguration::getId, BroadcasterConfigurationConfigurationManager.class);
+    }
+
+    @Override
+    protected ConfigurationRevisionManager<BroadcasterConfiguration> createManager(
+            BroadcasterConfigurationConfigurationManager configurationManager,
+            BroadcasterConfigurationRevisionFingerprinter fingerprinter,
+            LiveRegistry<BroadcasterConfiguration> liveRegistry) {
+        return new BroadcasterConfigurationConfigurationRevisionManager(
+                configurationManager, fingerprinter, liveRegistry);
+    }
+
+    @Override
+    protected BroadcasterConfigurationRevisionFingerprinter createFingerprinter() {
+        return new BroadcasterConfigurationRevisionFingerprinter(
+                new BroadcasterConfigurationNormalizer(
+                        new BroadcasterConfigurationNormalizerRegistry()));
+    }
+
+    @Override
+    protected BroadcasterConfiguration newItem() {
+        return new HttpBroadcasterConfigurationBuilder().build();
+    }
+
+    @Override
+    protected BroadcasterConfiguration updatedVariantOf(BroadcasterConfiguration base) {
+        return new HttpBroadcasterConfigurationBuilder().withId(base.getId()).build();
+    }
+}

--- a/core/src/test/java/io/naryo/application/broadcaster/revision/BroadcasterConfigurationRevisionManagerTest.java
+++ b/core/src/test/java/io/naryo/application/broadcaster/revision/BroadcasterConfigurationRevisionManagerTest.java
@@ -1,0 +1,43 @@
+package io.naryo.application.broadcaster.revision;
+
+import java.util.UUID;
+
+import io.naryo.application.broadcaster.configuration.manager.BroadcasterConfigurationManager;
+import io.naryo.application.configuration.revision.manager.BaseConfigurationRevisionManagerTest;
+import io.naryo.application.configuration.revision.manager.ConfigurationRevisionManager;
+import io.naryo.application.configuration.revision.registry.LiveRegistry;
+import io.naryo.domain.broadcaster.Broadcaster;
+import io.naryo.domain.broadcaster.BroadcasterBuilder;
+
+class BroadcasterConfigurationRevisionManagerTest
+        extends BaseConfigurationRevisionManagerTest<
+                Broadcaster, BroadcasterConfigurationManager, BroadcasterRevisionFingerprinter> {
+
+    protected BroadcasterConfigurationRevisionManagerTest() {
+        super(Broadcaster::getId, BroadcasterConfigurationManager.class);
+    }
+
+    @Override
+    protected ConfigurationRevisionManager<Broadcaster> createManager(
+            BroadcasterConfigurationManager configurationManager,
+            BroadcasterRevisionFingerprinter fingerprinter,
+            LiveRegistry<Broadcaster> liveRegistry) {
+        return new BroadcasterConfigurationRevisionManager(
+                configurationManager, fingerprinter, liveRegistry);
+    }
+
+    @Override
+    protected BroadcasterRevisionFingerprinter createFingerprinter() {
+        return new BroadcasterRevisionFingerprinter();
+    }
+
+    @Override
+    protected Broadcaster newItem() {
+        return new BroadcasterBuilder().build();
+    }
+
+    @Override
+    protected Broadcaster updatedVariantOf(Broadcaster base) {
+        return base.toBuilder().configurationId(UUID.randomUUID()).build();
+    }
+}

--- a/core/src/test/java/io/naryo/application/common/revision/BaseRevisionFingerprinterTest.java
+++ b/core/src/test/java/io/naryo/application/common/revision/BaseRevisionFingerprinterTest.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.function.Function;
 
+import io.naryo.application.configuration.revision.fingerprint.DefaultRevisionFingerprinter;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/core/src/test/java/io/naryo/application/configuration/revision/DefaultLiveRegistriesTest.java
+++ b/core/src/test/java/io/naryo/application/configuration/revision/DefaultLiveRegistriesTest.java
@@ -1,6 +1,7 @@
 package io.naryo.application.configuration.revision;
 
-import io.naryo.application.configuration.revision.impl.DefaultLiveRegistries;
+import io.naryo.application.configuration.revision.registry.DefaultLiveRegistries;
+import io.naryo.application.configuration.revision.registry.LiveRegistry;
 import io.naryo.domain.broadcaster.Broadcaster;
 import io.naryo.domain.common.http.HttpClient;
 import io.naryo.domain.configuration.broadcaster.BroadcasterConfiguration;

--- a/core/src/test/java/io/naryo/application/configuration/revision/DefaultLiveRegistryConcurrencyTest.java
+++ b/core/src/test/java/io/naryo/application/configuration/revision/DefaultLiveRegistryConcurrencyTest.java
@@ -6,7 +6,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import io.naryo.application.configuration.revision.impl.DefaultLiveRegistry;
+import io.naryo.application.configuration.revision.registry.DefaultLiveRegistry;
 import org.junit.jupiter.api.*;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/core/src/test/java/io/naryo/application/configuration/revision/manager/BaseConfigurationRevisionManagerTest.java
+++ b/core/src/test/java/io/naryo/application/configuration/revision/manager/BaseConfigurationRevisionManagerTest.java
@@ -1,0 +1,212 @@
+package io.naryo.application.configuration.revision.manager;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+
+import io.naryo.application.configuration.manager.CollectionConfigurationManager;
+import io.naryo.application.configuration.revision.LiveView;
+import io.naryo.application.configuration.revision.Revision;
+import io.naryo.application.configuration.revision.RevisionConflictException;
+import io.naryo.application.configuration.revision.diff.DiffResult;
+import io.naryo.application.configuration.revision.fingerprint.DefaultRevisionFingerprinter;
+import io.naryo.application.configuration.revision.hook.RevisionHook;
+import io.naryo.application.configuration.revision.operation.AddOperation;
+import io.naryo.application.configuration.revision.operation.RemoveOperation;
+import io.naryo.application.configuration.revision.operation.UpdateOperation;
+import io.naryo.application.configuration.revision.registry.LiveRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public abstract class BaseConfigurationRevisionManagerTest<
+        T, C extends CollectionConfigurationManager<T>, F extends DefaultRevisionFingerprinter<T>> {
+
+    protected ConfigurationRevisionManager<T> manager;
+    protected F fingerprinter;
+    protected C configurationManager;
+    protected LiveRegistry<T> liveRegistry;
+    protected RevisionHook<T> hookSpy;
+
+    protected final Function<T, UUID> idFn;
+    protected final Class<C> configurationManagerClass;
+
+    protected BaseConfigurationRevisionManagerTest(
+            Function<T, UUID> idFn, Class<C> configurationManagerClass) {
+        this.idFn = idFn;
+        this.configurationManagerClass = configurationManagerClass;
+    }
+
+    protected abstract ConfigurationRevisionManager<T> createManager(
+            C configurationManager, F fingerprinter, LiveRegistry<T> liveRegistry);
+
+    protected abstract F createFingerprinter();
+
+    protected abstract T newItem();
+
+    protected abstract T updatedVariantOf(T base);
+
+    protected UUID idOf(T item) {
+        return idFn.apply(item);
+    }
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        // Mocks
+        configurationManager = mock(configurationManagerClass);
+        liveRegistry = mock(LiveRegistry.class);
+        fingerprinter = spy(createFingerprinter());
+
+        when(configurationManager.load()).thenReturn(List.of());
+
+        manager = createManager(configurationManager, fingerprinter, liveRegistry);
+
+        hookSpy = mock(RevisionHook.class);
+        manager.registerHook(hookSpy);
+    }
+
+    @Test
+    void initialize_publishLiveViewYRefresh() throws Exception {
+        Revision<T> rev = manager.initialize();
+
+        assertNotNull(rev);
+        assertEquals(0L, rev.version());
+        assertNotNull(rev.hash());
+
+        LiveView<T> lv = manager.liveView();
+        assertNotNull(lv);
+        assertSame(rev, lv.revision());
+
+        verify(configurationManager, times(1)).load();
+        verify(liveRegistry, times(1)).refresh(rev);
+        verifyNoMoreInteractions(hookSpy);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void apply_addItem_and_bumpVersion_and_triggerHooks() throws Exception {
+        manager.initialize();
+        T item = newItem();
+        String itemHash = fingerprinter.itemHash(item);
+
+        Revision<T> after = manager.apply(new AddOperation<>(item));
+
+        assertNotNull(after);
+        assertEquals(1L, after.version());
+        assertTrue(after.domainItems().stream().anyMatch(i -> idOf(i).equals(idOf(item))));
+        assertEquals(itemHash, manager.liveView().itemFingerprintById().get(idFn.apply(item)));
+
+        ArgumentCaptor<Collection<T>> beforeCur = ArgumentCaptor.forClass(Collection.class);
+        ArgumentCaptor<Collection<T>> beforeNew = ArgumentCaptor.forClass(Collection.class);
+        verify(hookSpy, times(1)).onBeforeApply(beforeCur.capture(), beforeNew.capture());
+        assertTrue(beforeCur.getValue().isEmpty());
+        assertEquals(1, beforeNew.getValue().size());
+
+        ArgumentCaptor<Revision<T>> afterApplied = ArgumentCaptor.forClass(Revision.class);
+        ArgumentCaptor<DiffResult<T>> afterDiff = ArgumentCaptor.forClass(DiffResult.class);
+        verify(hookSpy, times(1)).onAfterApply(afterApplied.capture(), afterDiff.capture());
+        assertEquals(after, afterApplied.getValue());
+        assertNotNull(afterDiff.getValue());
+
+        Revision<T> again = manager.apply(new AddOperation<>(item));
+        assertSame(after, again);
+        assertEquals(1L, manager.liveView().revision().version());
+
+        verify(liveRegistry, times(2)).refresh(any());
+    }
+
+    @Test
+    void apply_updateWithPrevHash_andModifyItem() throws Exception {
+        manager.initialize();
+        T base = newItem();
+        manager.apply(new AddOperation<>(base));
+
+        String prevHash = fingerprinter.itemHash(base);
+        T updated = updatedVariantOf(base);
+
+        Revision<T> after =
+                manager.apply(new UpdateOperation<>(idFn.apply(base), prevHash, updated));
+
+        assertEquals(2L, after.version());
+        assertTrue(after.domainItems().stream().anyMatch(i -> idOf(i).equals(idOf(updated))));
+        assertEquals(
+                fingerprinter.itemHash(updated),
+                manager.liveView().itemFingerprintById().get(idFn.apply(updated)));
+
+        verify(hookSpy, atLeast(2)).onBeforeApply(any(), any());
+        verify(hookSpy, atLeast(2)).onAfterApply(any(), any());
+        verify(liveRegistry, times(3)).refresh(any());
+    }
+
+    @Test
+    void apply_updateWithIncorrectPrevHash_andThrowRevisionConflict() throws Exception {
+        manager.initialize();
+        T base = newItem();
+        manager.apply(new AddOperation<>(base));
+
+        String wrongPrev = "0x" + "00".repeat(32);
+        T updated = updatedVariantOf(base);
+
+        assertThrows(
+                RevisionConflictException.class,
+                () -> manager.apply(new UpdateOperation<>(idFn.apply(base), wrongPrev, updated)));
+
+        verify(liveRegistry, times(2)).refresh(any());
+        verify(hookSpy, times(1)).onBeforeApply(any(), any());
+        verify(hookSpy, times(1)).onAfterApply(any(), any());
+    }
+
+    @Test
+    void apply_removeWithPrevHash_andRemoveItem() throws Exception {
+        manager.initialize();
+        T base = newItem();
+        manager.apply(new AddOperation<>(base));
+        String prevHash = fingerprinter.itemHash(base);
+
+        Revision<T> after = manager.apply(new RemoveOperation<>(idFn.apply(base), prevHash));
+
+        assertEquals(2L, after.version());
+        assertTrue(after.domainItems().stream().noneMatch(i -> idOf(i).equals(idOf(base))));
+        verify(liveRegistry, times(3)).refresh(any());
+        verify(hookSpy, atLeast(2)).onBeforeApply(any(), any());
+        verify(hookSpy, atLeast(2)).onAfterApply(any(), any());
+    }
+
+    @Test
+    void apply_removeWithIncorrectPrevHash_triggerRevisionConflict() throws Exception {
+        manager.initialize();
+        T base = newItem();
+        manager.apply(new AddOperation<>(base));
+        String wrongPrev = "0x" + "ff".repeat(32);
+
+        assertThrows(
+                RevisionConflictException.class,
+                () -> manager.apply(new RemoveOperation<>(idFn.apply(base), wrongPrev)));
+
+        verify(liveRegistry, times(2)).refresh(any());
+        verify(hookSpy, times(1)).onBeforeApply(any(), any());
+        verify(hookSpy, times(1)).onAfterApply(any(), any());
+    }
+
+    @Test
+    void apply_addWithSameIdButDifferentContent_throwRevisionConflict() throws Exception {
+        manager.initialize();
+        T base = newItem();
+        manager.apply(new AddOperation<>(base));
+
+        T other = updatedVariantOf(base);
+
+        assertThrows(
+                RevisionConflictException.class, () -> manager.apply(new AddOperation<>(other)));
+
+        verify(liveRegistry, times(2)).refresh(any());
+
+        verify(hookSpy, times(1)).onBeforeApply(any(), any());
+        verify(hookSpy, times(1)).onAfterApply(any(), any());
+    }
+}

--- a/core/src/test/java/io/naryo/application/filter/revision/FilterConfigurationRevisionManagerTest.java
+++ b/core/src/test/java/io/naryo/application/filter/revision/FilterConfigurationRevisionManagerTest.java
@@ -1,0 +1,56 @@
+package io.naryo.application.filter.revision;
+
+import java.util.Random;
+
+import io.naryo.application.configuration.revision.manager.BaseConfigurationRevisionManagerTest;
+import io.naryo.application.configuration.revision.manager.ConfigurationRevisionManager;
+import io.naryo.application.configuration.revision.registry.LiveRegistry;
+import io.naryo.application.filter.configuration.manager.FilterConfigurationManager;
+import io.naryo.domain.filter.Filter;
+import io.naryo.domain.filter.FilterBuilder;
+import io.naryo.domain.filter.event.ContractEventFilterBuilder;
+import io.naryo.domain.filter.event.GlobalEventFilterBuilder;
+import io.naryo.domain.filter.transaction.TransactionFilterBuilder;
+
+class FilterConfigurationRevisionManagerTest
+        extends BaseConfigurationRevisionManagerTest<
+                Filter, FilterConfigurationManager, FilterRevisionFingerprinter> {
+
+    protected FilterConfigurationRevisionManagerTest() {
+        super(Filter::getId, FilterConfigurationManager.class);
+    }
+
+    @Override
+    protected ConfigurationRevisionManager<Filter> createManager(
+            FilterConfigurationManager configurationManager,
+            FilterRevisionFingerprinter fingerprinter,
+            LiveRegistry<Filter> liveRegistry) {
+        return new FilterConfigurationRevisionManager(
+                configurationManager, fingerprinter, liveRegistry);
+    }
+
+    @Override
+    protected FilterRevisionFingerprinter createFingerprinter() {
+        return new FilterRevisionFingerprinter();
+    }
+
+    @Override
+    protected Filter newItem() {
+        return newBuilder().build();
+    }
+
+    @Override
+    protected Filter updatedVariantOf(Filter base) {
+        return newBuilder().withId(base.getId()).build();
+    }
+
+    private FilterBuilder<?, ?> newBuilder() {
+        var random = new Random().nextInt(3);
+        return switch (random) {
+            case 0 -> new ContractEventFilterBuilder();
+            case 1 -> new GlobalEventFilterBuilder();
+            case 2 -> new TransactionFilterBuilder();
+            default -> throw new IllegalStateException("Unexpected value: " + random);
+        };
+    }
+}

--- a/core/src/test/java/io/naryo/application/node/revision/NodeConfigurationRevisionManagerTest.java
+++ b/core/src/test/java/io/naryo/application/node/revision/NodeConfigurationRevisionManagerTest.java
@@ -1,0 +1,58 @@
+package io.naryo.application.node.revision;
+
+import java.util.Random;
+
+import io.naryo.application.configuration.revision.manager.BaseConfigurationRevisionManagerTest;
+import io.naryo.application.configuration.revision.manager.ConfigurationRevisionManager;
+import io.naryo.application.configuration.revision.registry.LiveRegistry;
+import io.naryo.application.node.configuration.manager.NodeConfigurationManager;
+import io.naryo.domain.node.Node;
+import io.naryo.domain.node.NodeBuilder;
+import io.naryo.domain.node.eth.priv.PrivateEthereumNodeBuilder;
+import io.naryo.domain.node.eth.pub.PublicEthereumNodeBuilder;
+import io.naryo.domain.node.hedera.HederaNodeBuilder;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NodeConfigurationRevisionManagerTest
+        extends BaseConfigurationRevisionManagerTest<
+                Node, NodeConfigurationManager, NodeRevisionFingerprinter> {
+
+    protected NodeConfigurationRevisionManagerTest() {
+        super(Node::getId, NodeConfigurationManager.class);
+    }
+
+    @Override
+    protected ConfigurationRevisionManager<Node> createManager(
+            NodeConfigurationManager configurationManager,
+            NodeRevisionFingerprinter fingerprinter,
+            LiveRegistry<Node> liveRegistry) {
+        return new NodeConfigurationRevisionManager(
+                configurationManager, fingerprinter, liveRegistry);
+    }
+
+    @Override
+    protected NodeRevisionFingerprinter createFingerprinter() {
+        return new NodeRevisionFingerprinter();
+    }
+
+    @Override
+    protected Node newItem() {
+        return newBuilder().build();
+    }
+
+    @Override
+    protected Node updatedVariantOf(Node base) {
+        return newBuilder().withId(base.getId()).build();
+    }
+
+    private NodeBuilder<?, ?> newBuilder() {
+        var random = new Random().nextInt(3);
+        return switch (random) {
+            case 0 -> new PublicEthereumNodeBuilder();
+            case 1 -> new PrivateEthereumNodeBuilder();
+            case 2 -> new HederaNodeBuilder();
+            default -> throw new IllegalStateException("Unexpected value: " + random);
+        };
+    }
+}

--- a/core/src/test/java/io/naryo/application/store/revision/StoreConfigurationRevisionManagerTest.java
+++ b/core/src/test/java/io/naryo/application/store/revision/StoreConfigurationRevisionManagerTest.java
@@ -1,0 +1,60 @@
+package io.naryo.application.store.revision;
+
+import java.util.Random;
+
+import io.naryo.application.configuration.revision.manager.BaseConfigurationRevisionManagerTest;
+import io.naryo.application.configuration.revision.manager.ConfigurationRevisionManager;
+import io.naryo.application.configuration.revision.registry.LiveRegistry;
+import io.naryo.application.store.configuration.manager.StoreConfigurationManager;
+import io.naryo.application.store.configuration.normalization.ActiveStoreConfigurationNormalizerRegistry;
+import io.naryo.domain.configuration.store.StoreConfiguration;
+import io.naryo.domain.configuration.store.StoreConfigurationBuilder;
+import io.naryo.domain.configuration.store.StoreConfigurationNormalizer;
+import io.naryo.domain.configuration.store.active.ActiveStoreConfigurationNormalizer;
+import io.naryo.domain.configuration.store.active.HttpStoreConfigurationBuilder;
+import io.naryo.domain.configuration.store.inactive.InactiveStoreConfigurationBuilder;
+
+class StoreConfigurationRevisionManagerTest
+        extends BaseConfigurationRevisionManagerTest<
+                StoreConfiguration, StoreConfigurationManager, StoreRevisionFingerprinter> {
+
+    protected StoreConfigurationRevisionManagerTest() {
+        super(StoreConfiguration::getNodeId, StoreConfigurationManager.class);
+    }
+
+    @Override
+    protected ConfigurationRevisionManager<StoreConfiguration> createManager(
+            StoreConfigurationManager configurationManager,
+            StoreRevisionFingerprinter fingerprinter,
+            LiveRegistry<StoreConfiguration> liveRegistry) {
+        return new StoreConfigurationRevisionManager(
+                configurationManager, fingerprinter, liveRegistry);
+    }
+
+    @Override
+    protected StoreRevisionFingerprinter createFingerprinter() {
+        return new StoreRevisionFingerprinter(
+                new StoreConfigurationNormalizer(
+                        new ActiveStoreConfigurationNormalizer(
+                                new ActiveStoreConfigurationNormalizerRegistry())));
+    }
+
+    @Override
+    protected StoreConfiguration newItem() {
+        return newBuilder().build();
+    }
+
+    @Override
+    protected StoreConfiguration updatedVariantOf(StoreConfiguration base) {
+        return newBuilder().withNodeId(base.getNodeId()).build();
+    }
+
+    private StoreConfigurationBuilder<?, ?> newBuilder() {
+        var random = new Random().nextInt(2);
+        return switch (random) {
+            case 0 -> new InactiveStoreConfigurationBuilder();
+            case 1 -> new HttpStoreConfigurationBuilder();
+            default -> throw new IllegalStateException("Unexpected value: " + random);
+        };
+    }
+}

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/beans/liveConfiguration/RevisionAutoConfiguration.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/beans/liveConfiguration/RevisionAutoConfiguration.java
@@ -1,9 +1,9 @@
 package io.naryo.infrastructure.configuration.beans.liveConfiguration;
 
-import io.naryo.application.configuration.revision.LiveRegistries;
-import io.naryo.application.configuration.revision.LiveRegistry;
-import io.naryo.application.configuration.revision.impl.DefaultLiveRegistries;
-import io.naryo.application.configuration.revision.impl.DefaultLiveRegistry;
+import io.naryo.application.configuration.revision.registry.LiveRegistries;
+import io.naryo.application.configuration.revision.registry.LiveRegistry;
+import io.naryo.application.configuration.revision.registry.DefaultLiveRegistries;
+import io.naryo.application.configuration.revision.registry.DefaultLiveRegistry;
 import io.naryo.domain.broadcaster.Broadcaster;
 import io.naryo.domain.common.http.HttpClient;
 import io.naryo.domain.configuration.broadcaster.BroadcasterConfiguration;

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/beans/liveConfiguration/RevisionAutoConfiguration.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/beans/liveConfiguration/RevisionAutoConfiguration.java
@@ -1,9 +1,9 @@
 package io.naryo.infrastructure.configuration.beans.liveConfiguration;
 
-import io.naryo.application.configuration.revision.registry.LiveRegistries;
-import io.naryo.application.configuration.revision.registry.LiveRegistry;
 import io.naryo.application.configuration.revision.registry.DefaultLiveRegistries;
 import io.naryo.application.configuration.revision.registry.DefaultLiveRegistry;
+import io.naryo.application.configuration.revision.registry.LiveRegistries;
+import io.naryo.application.configuration.revision.registry.LiveRegistry;
 import io.naryo.domain.broadcaster.Broadcaster;
 import io.naryo.domain.common.http.HttpClient;
 import io.naryo.domain.configuration.broadcaster.BroadcasterConfiguration;

--- a/spring-core/src/main/java/io/naryo/infrastructure/configuration/beans/revision/RevisionConfigurationManagerAutoConfiguration.java
+++ b/spring-core/src/main/java/io/naryo/infrastructure/configuration/beans/revision/RevisionConfigurationManagerAutoConfiguration.java
@@ -1,0 +1,72 @@
+package io.naryo.infrastructure.configuration.beans.revision;
+
+import io.naryo.application.broadcaster.configuration.manager.BroadcasterConfigurationConfigurationManager;
+import io.naryo.application.broadcaster.configuration.manager.BroadcasterConfigurationManager;
+import io.naryo.application.broadcaster.configuration.revision.BroadcasterConfigurationConfigurationRevisionManager;
+import io.naryo.application.broadcaster.configuration.revision.BroadcasterConfigurationRevisionFingerprinter;
+import io.naryo.application.broadcaster.revision.BroadcasterConfigurationRevisionManager;
+import io.naryo.application.broadcaster.revision.BroadcasterRevisionFingerprinter;
+import io.naryo.application.configuration.revision.registry.LiveRegistry;
+import io.naryo.application.filter.configuration.manager.FilterConfigurationManager;
+import io.naryo.application.filter.revision.FilterConfigurationRevisionManager;
+import io.naryo.application.filter.revision.FilterRevisionFingerprinter;
+import io.naryo.application.node.configuration.manager.NodeConfigurationManager;
+import io.naryo.application.node.revision.NodeConfigurationRevisionManager;
+import io.naryo.application.node.revision.NodeRevisionFingerprinter;
+import io.naryo.application.store.configuration.manager.StoreConfigurationManager;
+import io.naryo.application.store.revision.StoreConfigurationRevisionManager;
+import io.naryo.application.store.revision.StoreRevisionFingerprinter;
+import io.naryo.domain.broadcaster.Broadcaster;
+import io.naryo.domain.configuration.broadcaster.BroadcasterConfiguration;
+import io.naryo.domain.configuration.store.StoreConfiguration;
+import io.naryo.domain.filter.Filter;
+import io.naryo.domain.node.Node;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RevisionConfigurationManagerAutoConfiguration {
+
+    @Bean
+    public NodeConfigurationRevisionManager nodeConfigurationRevisionManager(
+            NodeConfigurationManager configurationManager,
+            NodeRevisionFingerprinter fingerprinter,
+            LiveRegistry<Node> live) {
+        return new NodeConfigurationRevisionManager(configurationManager, fingerprinter, live);
+    }
+
+    @Bean
+    public BroadcasterConfigurationRevisionManager broadcasterConfigurationRevisionManager(
+            BroadcasterConfigurationManager configurationManager,
+            BroadcasterRevisionFingerprinter fingerprinter,
+            LiveRegistry<Broadcaster> live) {
+        return new BroadcasterConfigurationRevisionManager(
+                configurationManager, fingerprinter, live);
+    }
+
+    @Bean
+    public BroadcasterConfigurationConfigurationRevisionManager
+            broadcasterConfigurationConfigurationRevisionManager(
+                    BroadcasterConfigurationConfigurationManager configurationManager,
+                    BroadcasterConfigurationRevisionFingerprinter fingerprinter,
+                    LiveRegistry<BroadcasterConfiguration> live) {
+        return new BroadcasterConfigurationConfigurationRevisionManager(
+                configurationManager, fingerprinter, live);
+    }
+
+    @Bean
+    public FilterConfigurationRevisionManager filterConfigurationRevisionManager(
+            FilterConfigurationManager configurationManager,
+            FilterRevisionFingerprinter fingerprinter,
+            LiveRegistry<Filter> live) {
+        return new FilterConfigurationRevisionManager(configurationManager, fingerprinter, live);
+    }
+
+    @Bean
+    public StoreConfigurationRevisionManager storeConfigurationRevisionManager(
+            StoreConfigurationManager configurationManager,
+            StoreRevisionFingerprinter fingerprinter,
+            LiveRegistry<StoreConfiguration> live) {
+        return new StoreConfigurationRevisionManager(configurationManager, fingerprinter, live);
+    }
+}


### PR DESCRIPTION
Introduce a centralized ConfigurationRevisionManager (with a default implementation) to handle live configuration revisions across the application. This includes a full set of revision operations, fingerprinting, conflict handling, and per-domain managers (Broadcaster, Filter, Node, Store). Refactor related classes into clearer packages and wire the manager via Spring auto-configuration.