### PR TITLE
chore (jpa): Add persistence revision hooks

### DIFF
--- a/core/src/main/java/io/naryo/application/configuration/revision/hook/RevisionHook.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/hook/RevisionHook.java
@@ -7,7 +7,7 @@ import io.naryo.application.configuration.revision.diff.DiffResult;
 
 public interface RevisionHook<T> {
 
-    default void onBeforeApply(Collection<T> oldDomain, Collection<T> newDomain) throws Exception {}
+    default void onBeforeApply(DiffResult<T> diff) throws Exception {}
 
     default void onAfterApply(Revision<T> applied, DiffResult<T> diff) throws Exception {}
 }

--- a/core/src/main/java/io/naryo/application/configuration/revision/hook/RevisionHook.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/hook/RevisionHook.java
@@ -1,7 +1,5 @@
 package io.naryo.application.configuration.revision.hook;
 
-import java.util.Collection;
-
 import io.naryo.application.configuration.revision.Revision;
 import io.naryo.application.configuration.revision.diff.DiffResult;
 

--- a/core/src/main/java/io/naryo/application/configuration/revision/manager/DefaultConfigurationRevisionManager.java
+++ b/core/src/main/java/io/naryo/application/configuration/revision/manager/DefaultConfigurationRevisionManager.java
@@ -90,7 +90,7 @@ public abstract class DefaultConfigurationRevisionManager<T>
 
         for (var h : hooks) {
             try {
-                h.onBeforeApply(current, newDomain);
+                h.onBeforeApply(diff);
             } catch (Exception e) {
                 throw new RuntimeException("onBeforeApply hook error", e);
             }

--- a/core/src/test/java/io/naryo/application/configuration/revision/manager/BaseConfigurationRevisionManagerTest.java
+++ b/core/src/test/java/io/naryo/application/configuration/revision/manager/BaseConfigurationRevisionManagerTest.java
@@ -103,12 +103,13 @@ public abstract class BaseConfigurationRevisionManagerTest<
 
         ArgumentCaptor<Collection<T>> beforeCur = ArgumentCaptor.forClass(Collection.class);
         ArgumentCaptor<Collection<T>> beforeNew = ArgumentCaptor.forClass(Collection.class);
-        verify(hookSpy, times(1)).onBeforeApply(beforeCur.capture(), beforeNew.capture());
+        ArgumentCaptor<DiffResult<T>> afterDiff = ArgumentCaptor.forClass(DiffResult.class);
+        verify(hookSpy, times(1)).onBeforeApply(afterDiff.capture());
         assertTrue(beforeCur.getValue().isEmpty());
         assertEquals(1, beforeNew.getValue().size());
 
         ArgumentCaptor<Revision<T>> afterApplied = ArgumentCaptor.forClass(Revision.class);
-        ArgumentCaptor<DiffResult<T>> afterDiff = ArgumentCaptor.forClass(DiffResult.class);
+
         verify(hookSpy, times(1)).onAfterApply(afterApplied.capture(), afterDiff.capture());
         assertEquals(after, afterApplied.getValue());
         assertNotNull(afterDiff.getValue());
@@ -138,7 +139,7 @@ public abstract class BaseConfigurationRevisionManagerTest<
                 fingerprinter.itemHash(updated),
                 manager.liveView().itemFingerprintById().get(idFn.apply(updated)));
 
-        verify(hookSpy, atLeast(2)).onBeforeApply(any(), any());
+        verify(hookSpy, atLeast(2)).onBeforeApply(any());
         verify(hookSpy, atLeast(2)).onAfterApply(any(), any());
         verify(liveRegistry, times(3)).refresh(any());
     }
@@ -157,7 +158,7 @@ public abstract class BaseConfigurationRevisionManagerTest<
                 () -> manager.apply(new UpdateOperation<>(idFn.apply(base), wrongPrev, updated)));
 
         verify(liveRegistry, times(2)).refresh(any());
-        verify(hookSpy, times(1)).onBeforeApply(any(), any());
+        verify(hookSpy, times(1)).onBeforeApply(any());
         verify(hookSpy, times(1)).onAfterApply(any(), any());
     }
 
@@ -173,7 +174,7 @@ public abstract class BaseConfigurationRevisionManagerTest<
         assertEquals(2L, after.version());
         assertTrue(after.domainItems().stream().noneMatch(i -> idOf(i).equals(idOf(base))));
         verify(liveRegistry, times(3)).refresh(any());
-        verify(hookSpy, atLeast(2)).onBeforeApply(any(), any());
+        verify(hookSpy, atLeast(2)).onBeforeApply(any());
         verify(hookSpy, atLeast(2)).onAfterApply(any(), any());
     }
 
@@ -189,7 +190,7 @@ public abstract class BaseConfigurationRevisionManagerTest<
                 () -> manager.apply(new RemoveOperation<>(idFn.apply(base), wrongPrev)));
 
         verify(liveRegistry, times(2)).refresh(any());
-        verify(hookSpy, times(1)).onBeforeApply(any(), any());
+        verify(hookSpy, times(1)).onBeforeApply(any());
         verify(hookSpy, times(1)).onAfterApply(any(), any());
     }
 
@@ -206,7 +207,7 @@ public abstract class BaseConfigurationRevisionManagerTest<
 
         verify(liveRegistry, times(2)).refresh(any());
 
-        verify(hookSpy, times(1)).onBeforeApply(any(), any());
+        verify(hookSpy, times(1)).onBeforeApply(any());
         verify(hookSpy, times(1)).onAfterApply(any(), any());
     }
 }

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/BroadcasterEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/BroadcasterEntity.java
@@ -16,6 +16,8 @@ import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
+import static io.naryo.application.common.util.OptionalUtil.valueOrNull;
+
 @Entity
 @Table(name = "broadcaster")
 @AllArgsConstructor
@@ -56,31 +58,13 @@ public final class BroadcasterEntity implements BroadcasterDescriptor {
             return;
         }
 
-        switch (target) {
-            case BlockBroadcasterTargetDescriptor blockTarget ->
-                    this.target = new BlockBroadcasterTargetEntity(blockTarget.getDestinations());
+        this.target = BroadcasterTargetEntity.fromDescriptor(target);
+    }
 
-            case TransactionBroadcasterTargetDescriptor transactionTarget ->
-                    this.target =
-                            new TransactionBroadcasterTargetEntity(
-                                    transactionTarget.getDestinations());
-
-            case ContractEventBroadcasterTargetDescriptor contractEventTarget ->
-                    this.target =
-                            new ContractEventBroadcasterTargetEntity(
-                                    contractEventTarget.getDestinations());
-
-            case FilterBroadcasterTargetDescriptor filterTarget ->
-                    this.target =
-                            new FilterBroadcasterTargetEntity(
-                                    filterTarget.getDestinations(), filterTarget.getFilterId());
-
-            case AllBroadcasterTargetDescriptor allTarget ->
-                    this.target = new AllBroadcasterTargetEntity(allTarget.getDestinations());
-
-            default ->
-                    throw new IllegalArgumentException(
-                            "Unsupported target type: " + target.getClass().getSimpleName());
-        }
+    public static BroadcasterEntity fromDescriptor(BroadcasterDescriptor descriptor) {
+        return new BroadcasterEntity(
+                descriptor.getId(),
+                valueOrNull(descriptor.getConfigurationId()),
+                BroadcasterTargetEntity.fromDescriptor(valueOrNull(descriptor.getTarget())));
     }
 }

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/BroadcasterEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/BroadcasterEntity.java
@@ -4,12 +4,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import io.naryo.application.configuration.source.model.broadcaster.BroadcasterDescriptor;
-import io.naryo.application.configuration.source.model.broadcaster.target.AllBroadcasterTargetDescriptor;
-import io.naryo.application.configuration.source.model.broadcaster.target.BlockBroadcasterTargetDescriptor;
 import io.naryo.application.configuration.source.model.broadcaster.target.BroadcasterTargetDescriptor;
-import io.naryo.application.configuration.source.model.broadcaster.target.ContractEventBroadcasterTargetDescriptor;
-import io.naryo.application.configuration.source.model.broadcaster.target.FilterBroadcasterTargetDescriptor;
-import io.naryo.application.configuration.source.model.broadcaster.target.TransactionBroadcasterTargetDescriptor;
 import io.naryo.infrastructure.configuration.persistence.entity.broadcaster.target.*;
 import jakarta.persistence.*;
 import jakarta.validation.Valid;

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/configuration/BroadcasterConfigurationEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/configuration/BroadcasterConfigurationEntity.java
@@ -63,7 +63,8 @@ public final class BroadcasterConfigurationEntity implements BroadcasterConfigur
         return this.additionalProperties == null ? Map.of() : this.additionalProperties;
     }
 
-    public static BroadcasterConfigurationEntity fromDescriptor(BroadcasterConfigurationDescriptor descriptor) {
+    public static BroadcasterConfigurationEntity fromDescriptor(
+            BroadcasterConfigurationDescriptor descriptor) {
         return new BroadcasterConfigurationEntity(
                 descriptor.getId(),
                 descriptor.getType().getName(),

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/configuration/BroadcasterConfigurationEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/configuration/BroadcasterConfigurationEntity.java
@@ -16,6 +16,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import static io.naryo.application.common.util.OptionalUtil.valueOrNull;
+
 @Entity
 @Table(name = "broadcaster_configuration")
 @AllArgsConstructor
@@ -59,5 +61,13 @@ public final class BroadcasterConfigurationEntity implements BroadcasterConfigur
     @Override
     public Map<String, Object> getAdditionalProperties() {
         return this.additionalProperties == null ? Map.of() : this.additionalProperties;
+    }
+
+    public static BroadcasterConfigurationEntity fromDescriptor(BroadcasterConfigurationDescriptor descriptor) {
+        return new BroadcasterConfigurationEntity(
+                descriptor.getId(),
+                descriptor.getType().getName(),
+                valueOrNull(descriptor.getCache()),
+                descriptor.getAdditionalProperties());
     }
 }

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/target/BroadcasterTargetEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/target/BroadcasterTargetEntity.java
@@ -41,22 +41,25 @@ public abstract class BroadcasterTargetEntity implements BroadcasterTargetDescri
 
     public static BroadcasterTargetEntity fromDescriptor(BroadcasterTargetDescriptor descriptor) {
         return switch (descriptor) {
-            case BlockBroadcasterTargetDescriptor blockTarget -> new BlockBroadcasterTargetEntity(blockTarget.getDestinations());
+            case BlockBroadcasterTargetDescriptor blockTarget ->
+                    new BlockBroadcasterTargetEntity(blockTarget.getDestinations());
 
-            case TransactionBroadcasterTargetDescriptor transactionTarget -> new TransactionBroadcasterTargetEntity(
-                        transactionTarget.getDestinations());
+            case TransactionBroadcasterTargetDescriptor transactionTarget ->
+                    new TransactionBroadcasterTargetEntity(transactionTarget.getDestinations());
 
-            case ContractEventBroadcasterTargetDescriptor contractEventTarget -> new ContractEventBroadcasterTargetEntity(
-                        contractEventTarget.getDestinations());
+            case ContractEventBroadcasterTargetDescriptor contractEventTarget ->
+                    new ContractEventBroadcasterTargetEntity(contractEventTarget.getDestinations());
 
-            case FilterBroadcasterTargetDescriptor filterTarget -> new FilterBroadcasterTargetEntity(
-                        filterTarget.getDestinations(), filterTarget.getFilterId());
+            case FilterBroadcasterTargetDescriptor filterTarget ->
+                    new FilterBroadcasterTargetEntity(
+                            filterTarget.getDestinations(), filterTarget.getFilterId());
 
-            case AllBroadcasterTargetDescriptor allTarget ->  new AllBroadcasterTargetEntity(allTarget.getDestinations());
+            case AllBroadcasterTargetDescriptor allTarget ->
+                    new AllBroadcasterTargetEntity(allTarget.getDestinations());
 
             default ->
-                throw new IllegalArgumentException(
-                    "Unsupported target type: " + descriptor.getClass().getSimpleName());
+                    throw new IllegalArgumentException(
+                            "Unsupported target type: " + descriptor.getClass().getSimpleName());
         };
     }
 }

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/target/BroadcasterTargetEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/broadcaster/target/BroadcasterTargetEntity.java
@@ -4,7 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
-import io.naryo.application.configuration.source.model.broadcaster.target.BroadcasterTargetDescriptor;
+import io.naryo.application.configuration.source.model.broadcaster.target.*;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,5 +37,26 @@ public abstract class BroadcasterTargetEntity implements BroadcasterTargetDescri
     @Override
     public void setDestinations(Set<String> destinations) {
         this.destinations = new HashSet<>(destinations);
+    }
+
+    public static BroadcasterTargetEntity fromDescriptor(BroadcasterTargetDescriptor descriptor) {
+        return switch (descriptor) {
+            case BlockBroadcasterTargetDescriptor blockTarget -> new BlockBroadcasterTargetEntity(blockTarget.getDestinations());
+
+            case TransactionBroadcasterTargetDescriptor transactionTarget -> new TransactionBroadcasterTargetEntity(
+                        transactionTarget.getDestinations());
+
+            case ContractEventBroadcasterTargetDescriptor contractEventTarget -> new ContractEventBroadcasterTargetEntity(
+                        contractEventTarget.getDestinations());
+
+            case FilterBroadcasterTargetDescriptor filterTarget -> new FilterBroadcasterTargetEntity(
+                        filterTarget.getDestinations(), filterTarget.getFilterId());
+
+            case AllBroadcasterTargetDescriptor allTarget ->  new AllBroadcasterTargetEntity(allTarget.getDestinations());
+
+            default ->
+                throw new IllegalArgumentException(
+                    "Unsupported target type: " + descriptor.getClass().getSimpleName());
+        };
     }
 }

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/FilterEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/FilterEntity.java
@@ -58,34 +58,36 @@ public abstract class FilterEntity implements FilterDescriptor {
 
     public static FilterEntity fromDescriptor(FilterDescriptor descriptor) {
         return switch (descriptor) {
-            case ContractEventFilterDescriptor contract -> new ContractEventFilterEntity(
-                contract.getId(),
-                valueOrNull(contract.getName()),
-                valueOrNull(contract.getNodeId()),
-                valueOrNull(contract.getSpecification()),
-                contract.getStatuses(),
-                valueOrNull(contract.getSync()),
-                valueOrNull(contract.getVisibility()),
-                valueOrNull(contract.getAddress())
-            );
-            case GlobalEventFilterDescriptor global -> new GlobalEventFilterEntity(
-                global.getId(),
-                valueOrNull(global.getName()),
-                valueOrNull(global.getNodeId()),
-                valueOrNull(global.getSpecification()),
-                global.getStatuses(),
-                valueOrNull(global.getSync()),
-                valueOrNull(global.getVisibility())
-            );
-            case TransactionFilterDescriptor transaction -> new TransactionFilterEntity(
-                transaction.getId(),
-                valueOrNull(transaction.getName()),
-                valueOrNull(transaction.getNodeId()),
-                valueOrNull(transaction.getIdentifierType()),
-                valueOrNull(transaction.getValue()),
-                transaction.getStatuses()
-            );
-            default -> throw new IllegalStateException("Unsupported filter type: " + descriptor.getClass().getSimpleName());
+            case ContractEventFilterDescriptor contract ->
+                    new ContractEventFilterEntity(
+                            contract.getId(),
+                            valueOrNull(contract.getName()),
+                            valueOrNull(contract.getNodeId()),
+                            valueOrNull(contract.getSpecification()),
+                            contract.getStatuses(),
+                            valueOrNull(contract.getSync()),
+                            valueOrNull(contract.getVisibility()),
+                            valueOrNull(contract.getAddress()));
+            case GlobalEventFilterDescriptor global ->
+                    new GlobalEventFilterEntity(
+                            global.getId(),
+                            valueOrNull(global.getName()),
+                            valueOrNull(global.getNodeId()),
+                            valueOrNull(global.getSpecification()),
+                            global.getStatuses(),
+                            valueOrNull(global.getSync()),
+                            valueOrNull(global.getVisibility()));
+            case TransactionFilterDescriptor transaction ->
+                    new TransactionFilterEntity(
+                            transaction.getId(),
+                            valueOrNull(transaction.getName()),
+                            valueOrNull(transaction.getNodeId()),
+                            valueOrNull(transaction.getIdentifierType()),
+                            valueOrNull(transaction.getValue()),
+                            transaction.getStatuses());
+            default ->
+                    throw new IllegalStateException(
+                            "Unsupported filter type: " + descriptor.getClass().getSimpleName());
         };
     }
 }

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/FilterEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/filter/FilterEntity.java
@@ -4,10 +4,18 @@ import java.util.Optional;
 import java.util.UUID;
 
 import io.naryo.application.configuration.source.model.filter.FilterDescriptor;
+import io.naryo.application.configuration.source.model.filter.event.contract.ContractEventFilterDescriptor;
+import io.naryo.application.configuration.source.model.filter.event.global.GlobalEventFilterDescriptor;
+import io.naryo.application.configuration.source.model.filter.transaction.TransactionFilterDescriptor;
+import io.naryo.infrastructure.configuration.persistence.entity.filter.event.ContractEventFilterEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.filter.event.GlobalEventFilterEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.filter.transaction.TransactionFilterEntity;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
+
+import static io.naryo.application.common.util.OptionalUtil.valueOrNull;
 
 @Entity
 @Table(name = "filter")
@@ -46,5 +54,38 @@ public abstract class FilterEntity implements FilterDescriptor {
     @Override
     public Optional<UUID> getNodeId() {
         return nodeId == null ? Optional.empty() : Optional.of(nodeId);
+    }
+
+    public static FilterEntity fromDescriptor(FilterDescriptor descriptor) {
+        return switch (descriptor) {
+            case ContractEventFilterDescriptor contract -> new ContractEventFilterEntity(
+                contract.getId(),
+                valueOrNull(contract.getName()),
+                valueOrNull(contract.getNodeId()),
+                valueOrNull(contract.getSpecification()),
+                contract.getStatuses(),
+                valueOrNull(contract.getSync()),
+                valueOrNull(contract.getVisibility()),
+                valueOrNull(contract.getAddress())
+            );
+            case GlobalEventFilterDescriptor global -> new GlobalEventFilterEntity(
+                global.getId(),
+                valueOrNull(global.getName()),
+                valueOrNull(global.getNodeId()),
+                valueOrNull(global.getSpecification()),
+                global.getStatuses(),
+                valueOrNull(global.getSync()),
+                valueOrNull(global.getVisibility())
+            );
+            case TransactionFilterDescriptor transaction -> new TransactionFilterEntity(
+                transaction.getId(),
+                valueOrNull(transaction.getName()),
+                valueOrNull(transaction.getNodeId()),
+                valueOrNull(transaction.getIdentifierType()),
+                valueOrNull(transaction.getValue()),
+                transaction.getStatuses()
+            );
+            default -> throw new IllegalStateException("Unsupported filter type: " + descriptor.getClass().getSimpleName());
+        };
     }
 }

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/connection/ConnectionEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/connection/ConnectionEntity.java
@@ -3,10 +3,14 @@ package io.naryo.infrastructure.configuration.persistence.entity.node.connection
 import java.util.Optional;
 import java.util.UUID;
 
+import io.naryo.application.configuration.source.model.node.connection.HttpNodeConnectionDescriptor;
 import io.naryo.application.configuration.source.model.node.connection.NodeConnectionDescriptor;
+import io.naryo.application.configuration.source.model.node.connection.WsNodeConnectionDescriptor;
 import io.naryo.application.configuration.source.model.node.connection.endpoint.ConnectionEndpointDescriptor;
 import io.naryo.application.configuration.source.model.node.connection.retry.NodeConnectionRetryDescriptor;
 import io.naryo.infrastructure.configuration.persistence.entity.common.ConnectionEndpointEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.connection.http.HttpConnectionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.connection.ws.WsConnectionEntity;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import lombok.NoArgsConstructor;
@@ -60,5 +64,25 @@ public abstract class ConnectionEntity implements NodeConnectionDescriptor {
 
     public UUID getId() {
         return this.id;
+    }
+
+    public static ConnectionEntity fromDescriptor(NodeConnectionDescriptor descriptor) {
+        return switch (descriptor) {
+            case WsNodeConnectionDescriptor ws ->
+                    new WsConnectionEntity(
+                            valueOrNull(ws.getRetry()), valueOrNull(ws.getEndpoint()));
+            case HttpNodeConnectionDescriptor http ->
+                    new HttpConnectionEntity(
+                            valueOrNull(http.getRetry()),
+                            valueOrNull(http.getEndpoint()),
+                            valueOrNull(http.getMaxIdleConnections()),
+                            valueOrNull(http.getKeepAliveDuration()),
+                            valueOrNull(http.getConnectionTimeout()),
+                            valueOrNull(http.getReadTimeout()));
+            default ->
+                    throw new IllegalArgumentException(
+                            "Unsupported connection type: "
+                                    + descriptor.getClass().getSimpleName());
+        };
     }
 }

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/interaction/InteractionEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/interaction/InteractionEntity.java
@@ -2,9 +2,15 @@ package io.naryo.infrastructure.configuration.persistence.entity.node.interactio
 
 import java.util.UUID;
 
+import io.naryo.application.configuration.source.model.node.interaction.EthereumRpcBlockInteractionDescriptor;
+import io.naryo.application.configuration.source.model.node.interaction.HederaMirrorNodeBlockInteractionDescriptor;
 import io.naryo.application.configuration.source.model.node.interaction.InteractionDescriptor;
+import io.naryo.infrastructure.configuration.persistence.entity.node.interaction.block.EthereumRpcBlockInteractionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.interaction.block.HederaMirrorNodeBlockInteractionEntity;
 import jakarta.persistence.*;
 import lombok.NoArgsConstructor;
+
+import static io.naryo.application.common.util.OptionalUtil.valueOrNull;
 
 @Entity
 @Table(name = "node_interaction")
@@ -20,5 +26,20 @@ public abstract class InteractionEntity implements InteractionDescriptor {
 
     public java.util.UUID getId() {
         return this.id;
+    }
+
+    public static InteractionEntity fromDescriptor(InteractionDescriptor descriptor) {
+        return switch (descriptor) {
+            case EthereumRpcBlockInteractionDescriptor ignore ->
+                    new EthereumRpcBlockInteractionEntity();
+            case HederaMirrorNodeBlockInteractionDescriptor hedera ->
+                    new HederaMirrorNodeBlockInteractionEntity(
+                            valueOrNull(hedera.getLimitPerRequest()),
+                            valueOrNull(hedera.getRetriesPerRequest()));
+            default ->
+                    throw new IllegalArgumentException(
+                            "Unsupported interaction type: "
+                                    + descriptor.getClass().getSimpleName());
+        };
     }
 }

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/subscription/SubscriptionEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/node/subscription/SubscriptionEntity.java
@@ -2,10 +2,17 @@ package io.naryo.infrastructure.configuration.persistence.entity.node.subscripti
 
 import java.util.UUID;
 
+import io.naryo.application.configuration.source.model.node.subscription.BlockSubscriptionDescriptor;
+import io.naryo.application.configuration.source.model.node.subscription.PollBlockSubscriptionDescriptor;
+import io.naryo.application.configuration.source.model.node.subscription.PubsubBlockSubscriptionDescriptor;
 import io.naryo.application.configuration.source.model.node.subscription.SubscriptionDescriptor;
+import io.naryo.infrastructure.configuration.persistence.entity.node.subscription.block.PollBlockSubscriptionEntity;
+import io.naryo.infrastructure.configuration.persistence.entity.node.subscription.block.PubSubBlockSubscriptionEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import static io.naryo.application.common.util.OptionalUtil.valueOrNull;
 
 @Entity
 @Table(name = "node_subscription")
@@ -19,4 +26,31 @@ public abstract class SubscriptionEntity implements SubscriptionDescriptor {
     @Column(name = "id", nullable = false, updatable = false)
     @Getter
     private UUID id;
+
+    public static SubscriptionEntity fromDescriptor(SubscriptionDescriptor descriptor) {
+        BlockSubscriptionDescriptor blockDescriptor = (BlockSubscriptionDescriptor) descriptor;
+        return switch (blockDescriptor) {
+            case PollBlockSubscriptionDescriptor poll ->
+                    new PollBlockSubscriptionEntity(
+                            valueOrNull(poll.getInitialBlock()),
+                            valueOrNull(poll.getConfirmationBlocks()),
+                            valueOrNull(poll.getMissingTxRetryBlocks()),
+                            valueOrNull(poll.getEventInvalidationBlockThreshold()),
+                            valueOrNull(poll.getReplayBlockOffset()),
+                            valueOrNull(poll.getSyncBlockLimit()),
+                            valueOrNull(poll.getInterval()));
+            case PubsubBlockSubscriptionDescriptor pubsub ->
+                    new PubSubBlockSubscriptionEntity(
+                            valueOrNull(pubsub.getInitialBlock()),
+                            valueOrNull(pubsub.getConfirmationBlocks()),
+                            valueOrNull(pubsub.getMissingTxRetryBlocks()),
+                            valueOrNull(pubsub.getEventInvalidationBlockThreshold()),
+                            valueOrNull(pubsub.getReplayBlockOffset()),
+                            valueOrNull(pubsub.getSyncBlockLimit()));
+            default ->
+                    throw new IllegalArgumentException(
+                            "Unsupported subscription type: "
+                                    + descriptor.getClass().getSimpleName());
+        };
+    }
 }

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/store/ActiveStoreConfigurationEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/store/ActiveStoreConfigurationEntity.java
@@ -62,12 +62,6 @@ public class ActiveStoreConfigurationEntity extends StoreConfigurationEntity
     @Override
     public void setFeatures(
             Map<StoreFeatureType, ? extends StoreFeatureConfigurationDescriptor> features) {
-        if (features.values().stream()
-                .allMatch(f -> f instanceof StoreFeatureConfigurationEntity)) {
-            this.features = (List<StoreFeatureConfigurationEntity>) features.values();
-        } else {
-            throw new IllegalArgumentException(
-                    "Unsupported feature type for JPA entity: " + features.getClass());
-        }
+        this.features = StoreFeatureConfigurationEntity.flatFeaturesMap(features);
     }
 }

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/store/StoreConfigurationEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/store/StoreConfigurationEntity.java
@@ -30,14 +30,17 @@ public abstract class StoreConfigurationEntity implements StoreConfigurationDesc
 
     public static StoreConfigurationEntity fromDescriptor(StoreConfigurationDescriptor descriptor) {
         return switch (descriptor) {
-            case ActiveStoreConfigurationDescriptor active -> new ActiveStoreConfigurationEntity(
-                active.getNodeId(),
-                active.getType().getName(),
-                StoreFeatureConfigurationEntity.flatFeaturesMap(active.getFeatures()),
-                active.getAdditionalProperties()
-            );
-            case InactiveStoreConfigurationDescriptor inactive -> new InactiveStoreConfigurationEntity();
-            default -> throw new IllegalArgumentException("Unsupported store type: " + descriptor.getClass());
+            case ActiveStoreConfigurationDescriptor active ->
+                    new ActiveStoreConfigurationEntity(
+                            active.getNodeId(),
+                            active.getType().getName(),
+                            StoreFeatureConfigurationEntity.flatFeaturesMap(active.getFeatures()),
+                            active.getAdditionalProperties());
+            case InactiveStoreConfigurationDescriptor inactive ->
+                    new InactiveStoreConfigurationEntity();
+            default ->
+                    throw new IllegalArgumentException(
+                            "Unsupported store type: " + descriptor.getClass());
         };
     }
 }

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/store/StoreConfigurationEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/store/StoreConfigurationEntity.java
@@ -2,6 +2,8 @@ package io.naryo.infrastructure.configuration.persistence.entity.store;
 
 import java.util.UUID;
 
+import io.naryo.application.configuration.source.model.store.ActiveStoreConfigurationDescriptor;
+import io.naryo.application.configuration.source.model.store.InactiveStoreConfigurationDescriptor;
 import io.naryo.application.configuration.source.model.store.StoreConfigurationDescriptor;
 import jakarta.persistence.*;
 import lombok.NoArgsConstructor;
@@ -24,5 +26,18 @@ public abstract class StoreConfigurationEntity implements StoreConfigurationDesc
     @Override
     public UUID getNodeId() {
         return this.nodeId;
+    }
+
+    public static StoreConfigurationEntity fromDescriptor(StoreConfigurationDescriptor descriptor) {
+        return switch (descriptor) {
+            case ActiveStoreConfigurationDescriptor active -> new ActiveStoreConfigurationEntity(
+                active.getNodeId(),
+                active.getType().getName(),
+                StoreFeatureConfigurationEntity.flatFeaturesMap(active.getFeatures()),
+                active.getAdditionalProperties()
+            );
+            case InactiveStoreConfigurationDescriptor inactive -> new InactiveStoreConfigurationEntity();
+            default -> throw new IllegalArgumentException("Unsupported store type: " + descriptor.getClass());
+        };
     }
 }

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/store/StoreFeatureConfigurationEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/store/StoreFeatureConfigurationEntity.java
@@ -1,8 +1,11 @@
 package io.naryo.infrastructure.configuration.persistence.entity.store;
 
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import io.naryo.application.configuration.source.model.store.StoreFeatureConfigurationDescriptor;
+import io.naryo.domain.configuration.store.active.feature.StoreFeatureType;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -18,4 +21,14 @@ public abstract class StoreFeatureConfigurationEntity
             name = "id",
             nullable = false,
             updatable = false) UUID id;
+
+    public static List<StoreFeatureConfigurationEntity> flatFeaturesMap(Map<StoreFeatureType, ? extends StoreFeatureConfigurationDescriptor> features) {
+        if (features.values().stream()
+            .allMatch(f -> f instanceof StoreFeatureConfigurationEntity)) {
+            return (List<StoreFeatureConfigurationEntity>) features.values();
+        } else {
+            throw new IllegalArgumentException(
+                "Unsupported feature type for JPA entity: " + features.getClass());
+        }
+    }
 }

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/store/StoreFeatureConfigurationEntity.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/configuration/persistence/entity/store/StoreFeatureConfigurationEntity.java
@@ -22,13 +22,14 @@ public abstract class StoreFeatureConfigurationEntity
             nullable = false,
             updatable = false) UUID id;
 
-    public static List<StoreFeatureConfigurationEntity> flatFeaturesMap(Map<StoreFeatureType, ? extends StoreFeatureConfigurationDescriptor> features) {
+    public static List<StoreFeatureConfigurationEntity> flatFeaturesMap(
+            Map<StoreFeatureType, ? extends StoreFeatureConfigurationDescriptor> features) {
         if (features.values().stream()
-            .allMatch(f -> f instanceof StoreFeatureConfigurationEntity)) {
+                .allMatch(f -> f instanceof StoreFeatureConfigurationEntity)) {
             return (List<StoreFeatureConfigurationEntity>) features.values();
         } else {
             throw new IllegalArgumentException(
-                "Unsupported feature type for JPA entity: " + features.getClass());
+                    "Unsupported feature type for JPA entity: " + features.getClass());
         }
     }
 }

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/BroadcasterConfigurationRevisionHook.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/BroadcasterConfigurationRevisionHook.java
@@ -6,7 +6,9 @@ import io.naryo.application.configuration.revision.hook.RevisionHook;
 import io.naryo.application.configuration.source.model.broadcaster.configuration.BroadcasterConfigurationDescriptor;
 import io.naryo.infrastructure.configuration.persistence.entity.broadcaster.configuration.BroadcasterConfigurationEntity;
 import io.naryo.infrastructure.configuration.persistence.repository.broadcaster.BroadcasterConfigurationEntityRepository;
+import org.springframework.stereotype.Component;
 
+@Component
 public class BroadcasterConfigurationRevisionHook implements RevisionHook<BroadcasterConfigurationDescriptor> {
 
     private final BroadcasterConfigurationEntityRepository repository;

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/BroadcasterConfigurationRevisionHook.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/BroadcasterConfigurationRevisionHook.java
@@ -1,0 +1,45 @@
+package io.naryo.infrastructure.hook;
+
+import io.naryo.application.configuration.revision.Revision;
+import io.naryo.application.configuration.revision.diff.DiffResult;
+import io.naryo.application.configuration.revision.hook.RevisionHook;
+import io.naryo.application.configuration.source.model.broadcaster.configuration.BroadcasterConfigurationDescriptor;
+import io.naryo.infrastructure.configuration.persistence.entity.broadcaster.configuration.BroadcasterConfigurationEntity;
+import io.naryo.infrastructure.configuration.persistence.repository.broadcaster.BroadcasterConfigurationEntityRepository;
+
+public class BroadcasterConfigurationRevisionHook implements RevisionHook<BroadcasterConfigurationDescriptor> {
+
+    private final BroadcasterConfigurationEntityRepository repository;
+
+    public BroadcasterConfigurationRevisionHook(BroadcasterConfigurationEntityRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public void onBeforeApply(DiffResult<BroadcasterConfigurationDescriptor> diff) {
+        for (BroadcasterConfigurationDescriptor add : diff.added()) {
+            addBroadcasterConfiguration(add);
+        }
+        for (BroadcasterConfigurationDescriptor remove : diff.removed()) {
+            removeBroadcasterConfiguration(remove);
+        }
+        for (DiffResult.Modified<BroadcasterConfigurationDescriptor> modified : diff.modified()) {
+            updateBroadcasterConfiguration(modified.after());
+        }
+    }
+
+    @Override
+    public void onAfterApply(Revision<BroadcasterConfigurationDescriptor> applied, DiffResult<BroadcasterConfigurationDescriptor> diff) {}
+
+    private void addBroadcasterConfiguration(BroadcasterConfigurationDescriptor descriptor) {
+        repository.save(BroadcasterConfigurationEntity.fromDescriptor(descriptor));
+    }
+
+    private void removeBroadcasterConfiguration(BroadcasterConfigurationDescriptor descriptor) {
+        repository.deleteById(descriptor.getId());
+    }
+
+    private void updateBroadcasterConfiguration(BroadcasterConfigurationDescriptor descriptor) {
+        repository.findById(descriptor.getId()).ifPresent(repository::save);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/BroadcasterConfigurationRevisionHook.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/BroadcasterConfigurationRevisionHook.java
@@ -9,11 +9,13 @@ import io.naryo.infrastructure.configuration.persistence.repository.broadcaster.
 import org.springframework.stereotype.Component;
 
 @Component
-public class BroadcasterConfigurationRevisionHook implements RevisionHook<BroadcasterConfigurationDescriptor> {
+public class BroadcasterConfigurationRevisionHook
+        implements RevisionHook<BroadcasterConfigurationDescriptor> {
 
     private final BroadcasterConfigurationEntityRepository repository;
 
-    public BroadcasterConfigurationRevisionHook(BroadcasterConfigurationEntityRepository repository) {
+    public BroadcasterConfigurationRevisionHook(
+            BroadcasterConfigurationEntityRepository repository) {
         this.repository = repository;
     }
 
@@ -31,7 +33,9 @@ public class BroadcasterConfigurationRevisionHook implements RevisionHook<Broadc
     }
 
     @Override
-    public void onAfterApply(Revision<BroadcasterConfigurationDescriptor> applied, DiffResult<BroadcasterConfigurationDescriptor> diff) {}
+    public void onAfterApply(
+            Revision<BroadcasterConfigurationDescriptor> applied,
+            DiffResult<BroadcasterConfigurationDescriptor> diff) {}
 
     private void addBroadcasterConfiguration(BroadcasterConfigurationDescriptor descriptor) {
         repository.save(BroadcasterConfigurationEntity.fromDescriptor(descriptor));

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/BroadcasterRevisionHook.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/BroadcasterRevisionHook.java
@@ -6,7 +6,9 @@ import io.naryo.application.configuration.revision.hook.RevisionHook;
 import io.naryo.application.configuration.source.model.broadcaster.BroadcasterDescriptor;
 import io.naryo.infrastructure.configuration.persistence.entity.broadcaster.BroadcasterEntity;
 import io.naryo.infrastructure.configuration.persistence.repository.broadcaster.BroadcasterEntityRepository;
+import org.springframework.stereotype.Component;
 
+@Component
 public class BroadcasterRevisionHook implements RevisionHook<BroadcasterDescriptor> {
 
     private final BroadcasterEntityRepository repository;

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/BroadcasterRevisionHook.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/BroadcasterRevisionHook.java
@@ -31,8 +31,10 @@ public class BroadcasterRevisionHook implements RevisionHook<BroadcasterDescript
     }
 
     @Override
-    public void onAfterApply(Revision<BroadcasterDescriptor> applied, DiffResult<BroadcasterDescriptor> diff) {
-        // Run post-publication actions (e.g., selective filter sync; broadcaster add/remove/restart)
+    public void onAfterApply(
+            Revision<BroadcasterDescriptor> applied, DiffResult<BroadcasterDescriptor> diff) {
+        // Run post-publication actions (e.g., selective filter sync; broadcaster
+        // add/remove/restart)
     }
 
     private void addBroadcaster(BroadcasterDescriptor broadcaster) {

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/BroadcasterRevisionHook.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/BroadcasterRevisionHook.java
@@ -1,0 +1,47 @@
+package io.naryo.infrastructure.hook;
+
+import io.naryo.application.configuration.revision.Revision;
+import io.naryo.application.configuration.revision.diff.DiffResult;
+import io.naryo.application.configuration.revision.hook.RevisionHook;
+import io.naryo.application.configuration.source.model.broadcaster.BroadcasterDescriptor;
+import io.naryo.infrastructure.configuration.persistence.entity.broadcaster.BroadcasterEntity;
+import io.naryo.infrastructure.configuration.persistence.repository.broadcaster.BroadcasterEntityRepository;
+
+public class BroadcasterRevisionHook implements RevisionHook<BroadcasterDescriptor> {
+
+    private final BroadcasterEntityRepository repository;
+
+    public BroadcasterRevisionHook(BroadcasterEntityRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public void onBeforeApply(DiffResult<BroadcasterDescriptor> diff) {
+        for (BroadcasterDescriptor add : diff.added()) {
+            addBroadcaster(add);
+        }
+        for (BroadcasterDescriptor remove : diff.removed()) {
+            removeBroadcaster(remove);
+        }
+        for (DiffResult.Modified<BroadcasterDescriptor> modified : diff.modified()) {
+            updateBroadcaster(modified.after());
+        }
+    }
+
+    @Override
+    public void onAfterApply(Revision<BroadcasterDescriptor> applied, DiffResult<BroadcasterDescriptor> diff) {
+        // Run post-publication actions (e.g., selective filter sync; broadcaster add/remove/restart)
+    }
+
+    private void addBroadcaster(BroadcasterDescriptor broadcaster) {
+        repository.save(BroadcasterEntity.fromDescriptor(broadcaster));
+    }
+
+    private void removeBroadcaster(BroadcasterDescriptor broadcaster) {
+        repository.deleteById(broadcaster.getId());
+    }
+
+    private void updateBroadcaster(BroadcasterDescriptor broadcaster) {
+        repository.findById(broadcaster.getId()).ifPresent(repository::save);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/FilterRevisionHook.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/FilterRevisionHook.java
@@ -31,7 +31,8 @@ public class FilterRevisionHook implements RevisionHook<FilterDescriptor> {
     }
 
     @Override
-    public void onAfterApply(Revision<FilterDescriptor> applied, DiffResult<FilterDescriptor> diff) {}
+    public void onAfterApply(
+            Revision<FilterDescriptor> applied, DiffResult<FilterDescriptor> diff) {}
 
     private void addFilter(FilterDescriptor descriptor) {
         repository.save(FilterEntity.fromDescriptor(descriptor));

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/FilterRevisionHook.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/FilterRevisionHook.java
@@ -1,0 +1,45 @@
+package io.naryo.infrastructure.hook;
+
+import io.naryo.application.configuration.revision.Revision;
+import io.naryo.application.configuration.revision.diff.DiffResult;
+import io.naryo.application.configuration.revision.hook.RevisionHook;
+import io.naryo.application.configuration.source.model.filter.FilterDescriptor;
+import io.naryo.infrastructure.configuration.persistence.entity.filter.FilterEntity;
+import io.naryo.infrastructure.configuration.persistence.repository.filter.FilterEntityRepository;
+
+public class FilterRevisionHook implements RevisionHook<FilterDescriptor> {
+
+    private final FilterEntityRepository repository;
+
+    public FilterRevisionHook(FilterEntityRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public void onBeforeApply(DiffResult<FilterDescriptor> diff) {
+        for (FilterDescriptor add : diff.added()) {
+            addFilter(add);
+        }
+        for (FilterDescriptor remove : diff.removed()) {
+            removeFilter(remove);
+        }
+        for (DiffResult.Modified<FilterDescriptor> modified : diff.modified()) {
+            updateFilter(modified.after());
+        }
+    }
+
+    @Override
+    public void onAfterApply(Revision<FilterDescriptor> applied, DiffResult<FilterDescriptor> diff) {}
+
+    private void addFilter(FilterDescriptor descriptor) {
+        repository.save(FilterEntity.fromDescriptor(descriptor));
+    }
+
+    private void removeFilter(FilterDescriptor descriptor) {
+        repository.deleteById(descriptor.getId());
+    }
+
+    private void updateFilter(FilterDescriptor descriptor) {
+        repository.findById(descriptor.getId()).ifPresent(repository::save);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/FilterRevisionHook.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/FilterRevisionHook.java
@@ -6,7 +6,9 @@ import io.naryo.application.configuration.revision.hook.RevisionHook;
 import io.naryo.application.configuration.source.model.filter.FilterDescriptor;
 import io.naryo.infrastructure.configuration.persistence.entity.filter.FilterEntity;
 import io.naryo.infrastructure.configuration.persistence.repository.filter.FilterEntityRepository;
+import org.springframework.stereotype.Component;
 
+@Component
 public class FilterRevisionHook implements RevisionHook<FilterDescriptor> {
 
     private final FilterEntityRepository repository;

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/JpaRevisionHookInitializer.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/JpaRevisionHookInitializer.java
@@ -1,0 +1,13 @@
+package io.naryo.infrastructure.hook;
+
+public class JpaRevisionHookInitializer {
+
+    // private final DefaultRevisionHookBinder defaultRevisionHookBinder;
+
+    public JpaRevisionHookInitializer() {}
+
+    public void initialize() {
+        // Todo: registers the corresponding hook for each domain
+        //  example: defaultRevisionHookBinder.register(NodeEntity.class, NodeRevisionHook::new);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/JpaRevisionHookInitializer.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/JpaRevisionHookInitializer.java
@@ -1,5 +1,8 @@
 package io.naryo.infrastructure.hook;
 
+import org.springframework.stereotype.Component;
+
+@Component
 public class JpaRevisionHookInitializer {
 
     // private final DefaultRevisionHookBinder defaultRevisionHookBinder;

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/NodeRevisionHook.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/NodeRevisionHook.java
@@ -6,7 +6,9 @@ import io.naryo.application.configuration.revision.hook.RevisionHook;
 import io.naryo.application.configuration.source.model.node.NodeDescriptor;
 import io.naryo.infrastructure.configuration.persistence.entity.node.NodeEntity;
 import io.naryo.infrastructure.configuration.persistence.repository.node.NodeEntityRepository;
+import org.springframework.stereotype.Component;
 
+@Component
 public class NodeRevisionHook implements RevisionHook<NodeDescriptor> {
 
     private final NodeEntityRepository repository;

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/NodeRevisionHook.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/NodeRevisionHook.java
@@ -1,0 +1,48 @@
+package io.naryo.infrastructure.hook;
+
+import io.naryo.application.configuration.revision.Revision;
+import io.naryo.application.configuration.revision.diff.DiffResult;
+import io.naryo.application.configuration.revision.hook.RevisionHook;
+import io.naryo.application.configuration.source.model.node.NodeDescriptor;
+import io.naryo.infrastructure.configuration.persistence.entity.node.NodeEntity;
+import io.naryo.infrastructure.configuration.persistence.repository.node.NodeEntityRepository;
+
+public class NodeRevisionHook implements RevisionHook<NodeDescriptor> {
+
+    private final NodeEntityRepository repository;
+
+    public NodeRevisionHook(NodeEntityRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public void onBeforeApply(DiffResult<NodeDescriptor> diff) {
+        // Todo: manage each diffResult array: add/remove/update nodes
+        for (NodeDescriptor add : diff.added()) {
+            addNode(add);
+        }
+        for (NodeDescriptor remove : diff.removed()) {
+            removeNode(remove);
+        }
+        for (DiffResult.Modified<NodeDescriptor> modified : diff.modified()) {
+            updateNode(modified.after());
+        }
+    }
+
+    @Override
+    public void onAfterApply(Revision<NodeDescriptor> applied, DiffResult<NodeDescriptor> diff) {
+        // Run post-publication actions (e.g., selective filter sync; node add/remove/restart)
+    }
+
+    private void addNode(NodeDescriptor descriptor) {
+        repository.save(NodeEntity.fromDescriptor(descriptor));
+    }
+
+    private void removeNode(NodeDescriptor descriptor) {
+        repository.deleteById(descriptor.getId());
+    }
+
+    private void updateNode(NodeDescriptor descriptor) {
+        repository.findById(descriptor.getId()).ifPresent(repository::save);
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/StoreRevisionHook.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/StoreRevisionHook.java
@@ -6,7 +6,9 @@ import io.naryo.application.configuration.revision.hook.RevisionHook;
 import io.naryo.application.configuration.source.model.store.StoreConfigurationDescriptor;
 import io.naryo.infrastructure.configuration.persistence.entity.store.StoreConfigurationEntity;
 import io.naryo.infrastructure.configuration.persistence.repository.store.StoreConfigurationEntityRepository;
+import org.springframework.stereotype.Component;
 
+@Component
 public class StoreRevisionHook implements RevisionHook<StoreConfigurationDescriptor> {
 
     private final StoreConfigurationEntityRepository repository;

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/StoreRevisionHook.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/StoreRevisionHook.java
@@ -1,0 +1,48 @@
+package io.naryo.infrastructure.hook;
+
+import io.naryo.application.configuration.revision.Revision;
+import io.naryo.application.configuration.revision.diff.DiffResult;
+import io.naryo.application.configuration.revision.hook.RevisionHook;
+import io.naryo.application.configuration.source.model.store.StoreConfigurationDescriptor;
+import io.naryo.infrastructure.configuration.persistence.entity.store.StoreConfigurationEntity;
+import io.naryo.infrastructure.configuration.persistence.repository.store.StoreConfigurationEntityRepository;
+
+public class StoreRevisionHook implements RevisionHook<StoreConfigurationDescriptor> {
+
+    private final StoreConfigurationEntityRepository repository;
+
+    public StoreRevisionHook(StoreConfigurationEntityRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public void onBeforeApply(DiffResult<StoreConfigurationDescriptor> diff) {
+        for (StoreConfigurationDescriptor add : diff.added()) {
+            addStore(add);
+        }
+        for (StoreConfigurationDescriptor remove : diff.removed()) {
+            removeStore(remove);
+        }
+        for (DiffResult.Modified<StoreConfigurationDescriptor> modified : diff.modified()) {
+            updateStore(modified.after());
+        }
+    }
+
+    @Override
+    public void onAfterApply(Revision<StoreConfigurationDescriptor> applied, DiffResult<StoreConfigurationDescriptor> diff) {
+        // Run post-publication actions (e.g., selective filter sync; broadcaster add/remove/restart)
+    }
+
+    private void addStore(StoreConfigurationDescriptor descriptor) {
+        this.repository.save(StoreConfigurationEntity.fromDescriptor(descriptor));
+    }
+
+    private void removeStore(StoreConfigurationDescriptor descriptor) {
+         repository.deleteById(descriptor.getNodeId());
+    }
+
+    private void updateStore(StoreConfigurationDescriptor descriptor) {
+        repository.findById(descriptor.getNodeId()).ifPresent(repository::save);
+
+    }
+}

--- a/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/StoreRevisionHook.java
+++ b/persistence-spring-jpa/src/main/java/io/naryo/infrastructure/hook/StoreRevisionHook.java
@@ -31,8 +31,11 @@ public class StoreRevisionHook implements RevisionHook<StoreConfigurationDescrip
     }
 
     @Override
-    public void onAfterApply(Revision<StoreConfigurationDescriptor> applied, DiffResult<StoreConfigurationDescriptor> diff) {
-        // Run post-publication actions (e.g., selective filter sync; broadcaster add/remove/restart)
+    public void onAfterApply(
+            Revision<StoreConfigurationDescriptor> applied,
+            DiffResult<StoreConfigurationDescriptor> diff) {
+        // Run post-publication actions (e.g., selective filter sync; broadcaster
+        // add/remove/restart)
     }
 
     private void addStore(StoreConfigurationDescriptor descriptor) {
@@ -40,11 +43,10 @@ public class StoreRevisionHook implements RevisionHook<StoreConfigurationDescrip
     }
 
     private void removeStore(StoreConfigurationDescriptor descriptor) {
-         repository.deleteById(descriptor.getNodeId());
+        repository.deleteById(descriptor.getNodeId());
     }
 
     private void updateStore(StoreConfigurationDescriptor descriptor) {
         repository.findById(descriptor.getNodeId()).ifPresent(repository::save);
-
     }
 }

--- a/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/http/HttpClientPropertiesDocument.java
+++ b/persistence-spring-mongo/src/main/java/io/naryo/infrastructure/configuration/persistence/document/http/HttpClientPropertiesDocument.java
@@ -1,0 +1,42 @@
+package io.naryo.infrastructure.configuration.persistence.document.http;
+
+import java.time.Duration;
+
+import jakarta.annotation.Nullable;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.MongoId;
+
+@Document(collection = "http_clients")
+public class HttpClientPropertiesDocument {
+
+    private final @MongoId String id;
+    private @Nullable Integer maxIdleConnections;
+    private @Nullable Duration keepAliveDuration;
+    private @Nullable Duration connectTimeout;
+    private @Nullable Duration readTimeout;
+    private @Nullable Duration writeTimeout;
+    private @Nullable Duration callTimeout;
+    private @Nullable Duration pingInterval;
+    private @Nullable Boolean retryOnConnectionFailure;
+
+    public HttpClientPropertiesDocument(
+            String id,
+            Integer maxIdleConnections,
+            Duration keepAliveDuration,
+            Duration connectTimeout,
+            Duration readTimeout,
+            Duration writeTimeout,
+            Duration callTimeout,
+            Duration pingInterval,
+            Boolean retryOnConnectionFailure) {
+        this.id = id;
+        this.maxIdleConnections = maxIdleConnections;
+        this.keepAliveDuration = keepAliveDuration;
+        this.connectTimeout = connectTimeout;
+        this.readTimeout = readTimeout;
+        this.writeTimeout = writeTimeout;
+        this.callTimeout = callTimeout;
+        this.pingInterval = pingInterval;
+        this.retryOnConnectionFailure = retryOnConnectionFailure;
+    }
+}


### PR DESCRIPTION
- **persistence-spring-jpa**
  - Implement `RevisionHook` interface to store changes in configuration entities 
- **core**
  -  Use DiffResult in `RevisionHook<T>` to ease onBeforeChange logic implementation